### PR TITLE
exclude otel services by detecting grpc port of otel exports

### DIFF
--- a/pkg/app/request/span.go
+++ b/pkg/app/request/span.go
@@ -6,6 +6,7 @@ package request
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,16 @@ const (
 	EventTypeGPUKernelLaunch
 	EventTypeGPUMalloc
 	EventTypeGPUMemcpy
+)
+
+const (
+	envOTLPProtocol        = "OTEL_EXPORTER_OTLP_PROTOCOL"
+	envOTLPTracesProtocol  = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
+	envOTLPMetricsProtocol = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
+	envOTLPEndpoint        = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	envOTLPTracesEndpoint  = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+	envOTLPMetricsEndpoint = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+	otlpGrpcProtocol       = "grpc"
 )
 
 const (
@@ -617,22 +628,78 @@ func (s *Span) isTracesExportURL() bool {
 	}
 }
 
-func (s *Span) IsExportMetricsSpan() bool {
-	// check if it's a successful client call
-	if !s.isHTTPOrGRPCClient() || (SpanStatusCode(s) != StatusCodeUnset) {
+func (s *Span) sendsTracesOnOtelGrpcPort(defaultOtlpGRPCPort int) bool {
+	otlpTracesProtocol, ok := s.Service.EnvVars[envOTLPTracesProtocol]
+	if ok && otlpTracesProtocol != otlpGrpcProtocol {
 		return false
 	}
-
-	return s.isMetricsExportURL()
+	otlpProtocol, ok := s.Service.EnvVars[envOTLPProtocol]
+	if ok && otlpProtocol != otlpGrpcProtocol {
+		return false
+	}
+	otlpTracesPort, ok := s.portFromEndpointEnvVar(envOTLPTracesEndpoint)
+	if ok {
+		return otlpTracesPort == s.PeerPort
+	}
+	otlpPort, ok := s.portFromEndpointEnvVar(envOTLPEndpoint)
+	if ok {
+		return otlpPort == s.PeerPort
+	}
+	return s.PeerPort == defaultOtlpGRPCPort
 }
 
-func (s *Span) IsExportTracesSpan() bool {
+func (s *Span) sendsMetricsOnOtelGrpcPort(defaultOtlpGRPCPort int) bool {
+	otlpMetricsProtocol, ok := s.Service.EnvVars[envOTLPMetricsProtocol]
+	if ok && otlpMetricsProtocol != otlpGrpcProtocol {
+		return false
+	}
+	otlpProtocol, ok := s.Service.EnvVars[envOTLPProtocol]
+	if ok && otlpProtocol != otlpGrpcProtocol {
+		return false
+	}
+	otlpMetricsPort, ok := s.portFromEndpointEnvVar(envOTLPMetricsEndpoint)
+	if ok {
+		return otlpMetricsPort == s.PeerPort
+	}
+	otlpPort, ok := s.portFromEndpointEnvVar(envOTLPEndpoint)
+	if ok {
+		return otlpPort == s.PeerPort
+	}
+	return s.PeerPort == defaultOtlpGRPCPort
+}
+
+func (s *Span) portFromEndpointEnvVar(envVarName string) (int, bool) {
+	endpoint, ok := s.Service.EnvVars[envVarName]
+	if !ok {
+		return 0, false
+	}
+	parsedURL, err := url.Parse(endpoint)
+	if err != nil && parsedURL == nil {
+		return 0, false
+	}
+	port, err := strconv.Atoi(parsedURL.Port())
+	if err != nil {
+		return 0, false
+	}
+	return port, true
+}
+
+func (s *Span) IsExportMetricsSpan(defaultOtlpGRPCPort int) bool {
 	// check if it's a successful client call
 	if !s.isHTTPOrGRPCClient() || (SpanStatusCode(s) != StatusCodeUnset) {
 		return false
 	}
 
-	return s.isTracesExportURL()
+	return s.isMetricsExportURL() || s.sendsMetricsOnOtelGrpcPort(defaultOtlpGRPCPort)
+}
+
+func (s *Span) IsExportTracesSpan(defaultOtlpGRPCPort int) bool {
+	// check if it's a successful client call
+	if !s.isHTTPOrGRPCClient() || (SpanStatusCode(s) != StatusCodeUnset) {
+		return false
+	}
+
+	return s.isTracesExportURL() || s.sendsTracesOnOtelGrpcPort(defaultOtlpGRPCPort)
 }
 
 func (s *Span) IsSelfReferenceSpan() bool {

--- a/pkg/app/request/span.go
+++ b/pkg/app/request/span.go
@@ -628,6 +628,14 @@ func (s *Span) isTracesExportURL() bool {
 	}
 }
 
+func (s *Span) sendsOnDefaultGrpcOtelPort(defaultOtlpGRPCPort int) bool {
+	otlpPort, ok := s.portFromEndpointEnvVar(envOTLPEndpoint)
+	if ok {
+		return otlpPort == s.PeerPort
+	}
+	return s.PeerPort == defaultOtlpGRPCPort
+}
+
 func (s *Span) sendsTracesOnGrpcOtelPort(defaultOtlpGRPCPort int) bool {
 	otlpTracesProtocol, ok := s.Service.EnvVars[envOTLPTracesProtocol]
 	if ok && otlpTracesProtocol != otlpGrpcProtocol {
@@ -641,11 +649,7 @@ func (s *Span) sendsTracesOnGrpcOtelPort(defaultOtlpGRPCPort int) bool {
 	if ok {
 		return otlpTracesPort == s.PeerPort
 	}
-	otlpPort, ok := s.portFromEndpointEnvVar(envOTLPEndpoint)
-	if ok {
-		return otlpPort == s.PeerPort
-	}
-	return s.PeerPort == defaultOtlpGRPCPort
+	return s.sendsOnDefaultGrpcOtelPort(defaultOtlpGRPCPort)
 }
 
 func (s *Span) sendsMetricsOnOtelPort(defaultOtlpGRPCPort int) bool {
@@ -679,11 +683,7 @@ func (s *Span) sendsMetricsOnGrpcOtelPort(defaultOtlpGRPCPort int) bool {
 	if ok {
 		return otlpMetricsPort == s.PeerPort
 	}
-	otlpPort, ok := s.portFromEndpointEnvVar(envOTLPEndpoint)
-	if ok {
-		return otlpPort == s.PeerPort
-	}
-	return s.PeerPort == defaultOtlpGRPCPort
+	return s.sendsOnDefaultGrpcOtelPort(defaultOtlpGRPCPort)
 }
 
 func (s *Span) portFromEndpointEnvVar(envVarName string) (int, bool) {

--- a/pkg/app/request/span.go
+++ b/pkg/app/request/span.go
@@ -628,7 +628,7 @@ func (s *Span) isTracesExportURL() bool {
 	}
 }
 
-func (s *Span) sendsTracesOnOtelGrpcPort(defaultOtlpGRPCPort int) bool {
+func (s *Span) sendsTracesOnGrpcOtelPort(defaultOtlpGRPCPort int) bool {
 	otlpTracesProtocol, ok := s.Service.EnvVars[envOTLPTracesProtocol]
 	if ok && otlpTracesProtocol != otlpGrpcProtocol {
 		return false
@@ -648,7 +648,25 @@ func (s *Span) sendsTracesOnOtelGrpcPort(defaultOtlpGRPCPort int) bool {
 	return s.PeerPort == defaultOtlpGRPCPort
 }
 
-func (s *Span) sendsMetricsOnOtelGrpcPort(defaultOtlpGRPCPort int) bool {
+func (s *Span) sendsMetricsOnOtelPort(defaultOtlpGRPCPort int) bool {
+	switch s.Type {
+	case EventTypeGRPCClient:
+		return s.sendsMetricsOnGrpcOtelPort(defaultOtlpGRPCPort)
+	default:
+		return false
+	}
+}
+
+func (s *Span) sendsTracesOnOtelPort(defaultOtlpGRPCPort int) bool {
+	switch s.Type {
+	case EventTypeGRPCClient:
+		return s.sendsTracesOnGrpcOtelPort(defaultOtlpGRPCPort)
+	default:
+		return false
+	}
+}
+
+func (s *Span) sendsMetricsOnGrpcOtelPort(defaultOtlpGRPCPort int) bool {
 	otlpMetricsProtocol, ok := s.Service.EnvVars[envOTLPMetricsProtocol]
 	if ok && otlpMetricsProtocol != otlpGrpcProtocol {
 		return false
@@ -690,7 +708,7 @@ func (s *Span) IsExportMetricsSpan(defaultOtlpGRPCPort int) bool {
 		return false
 	}
 
-	return s.isMetricsExportURL() || s.sendsMetricsOnOtelGrpcPort(defaultOtlpGRPCPort)
+	return s.isMetricsExportURL() || s.sendsMetricsOnOtelPort(defaultOtlpGRPCPort)
 }
 
 func (s *Span) IsExportTracesSpan(defaultOtlpGRPCPort int) bool {
@@ -699,7 +717,7 @@ func (s *Span) IsExportTracesSpan(defaultOtlpGRPCPort int) bool {
 		return false
 	}
 
-	return s.isTracesExportURL() || s.sendsTracesOnOtelGrpcPort(defaultOtlpGRPCPort)
+	return s.isTracesExportURL() || s.sendsTracesOnOtelPort(defaultOtlpGRPCPort)
 }
 
 func (s *Span) IsSelfReferenceSpan() bool {

--- a/pkg/app/request/span.go
+++ b/pkg/app/request/span.go
@@ -692,7 +692,7 @@ func (s *Span) portFromEndpointEnvVar(envVarName string) (int, bool) {
 		return 0, false
 	}
 	parsedURL, err := url.Parse(endpoint)
-	if err != nil && parsedURL == nil {
+	if err != nil || parsedURL == nil {
 		return 0, false
 	}
 	port, err := strconv.Atoi(parsedURL.Port())

--- a/pkg/app/request/span_test.go
+++ b/pkg/app/request/span_test.go
@@ -322,56 +322,74 @@ func TestDetectsOTelExport(t *testing.T) {
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL != grpc doesn't export",
-			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_PROTOCOL != grpc doesn't export",
-			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT is not a valid endpoint doesn't export",
-			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "notanendpoint"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "notanendpoint"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_ENDPOINT is not a valid endpoint doesn't export",
-			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "notanendpoint"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "notanendpoint"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT != span.PeerPort doesn't export",
-			span: Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4317"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4317"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_ENDPOINT != span.PeerPort doesn't export",
-			span: Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT == span.PeerPort export",
-			span: Span{Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:9090"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:9090"}},
+			},
 			exports: true,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_ENDPOINT == span.PeerPort export",
-			span: Span{Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:9090", "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:9090", "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"}},
+			},
 			exports: true,
 		},
 		{
 			name: fmt.Sprintf("no otel metrics environment sends to %x export", defaultOtlpGRPCPort),
-			span: Span{Type: EventTypeGRPCClient, PeerPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, PeerPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"}},
+			},
 			exports: true,
 		},
 		{
@@ -436,56 +454,74 @@ func TestDetectsOTelExport(t *testing.T) {
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL != grpc doesn't export",
-			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_PROTOCOL != grpc doesn't export",
-			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is not a valid endpoint doesn't export",
-			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "notanendpoint"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "notanendpoint"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_ENDPOINT is not a valid endpoint doesn't export",
-			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "notanendpoint"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "notanendpoint"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT != span.PeerPort doesn't export",
-			span: Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4317"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4317"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_ENDPOINT != span.PeerPort doesn't export",
-			span: Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"}},
+			},
 			exports: false,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT == span.PeerPort export",
-			span: Span{Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:9090"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:9090"}},
+			},
 			exports: true,
 		},
 		{
 			name: "OTEL_EXPORTER_OTLP_ENDPOINT == span.PeerPort export",
-			span: Span{Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:9090", "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:9090", "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf"}},
+			},
 			exports: true,
 		},
 		{
 			name: fmt.Sprintf("no otel traces environment sends to %d export", defaultOtlpGRPCPort),
-			span: Span{Type: EventTypeGRPCClient, PeerPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
-				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf"}}},
+			span: Span{
+				Type: EventTypeGRPCClient, PeerPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf"}},
+			},
 			exports: true,
 		},
 		{

--- a/pkg/app/request/span_test.go
+++ b/pkg/app/request/span_test.go
@@ -5,6 +5,7 @@ package request
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -267,6 +268,7 @@ func TestSerializeJSONSpans(t *testing.T) {
 }
 
 func TestDetectsOTelExport(t *testing.T) {
+	const defaultOtlpGRPCPort = 4317
 	// Metrics
 	tests := []struct {
 		name    string
@@ -318,12 +320,71 @@ func TestDetectsOTelExport(t *testing.T) {
 			span:    Span{Type: EventTypeGRPCClient, Method: "GET", Path: "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export", RequestStart: 100, End: 200, Status: 0},
 			exports: true,
 		},
+		{
+			name: "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL != grpc doesn't export",
+			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_PROTOCOL != grpc doesn't export",
+			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT is not a valid endpoint doesn't export",
+			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "notanendpoint"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_ENDPOINT is not a valid endpoint doesn't export",
+			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "notanendpoint"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT != span.PeerPort doesn't export",
+			span: Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4317"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_ENDPOINT != span.PeerPort doesn't export",
+			span: Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT == span.PeerPort export",
+			span: Span{Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:9090"}}},
+			exports: true,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_ENDPOINT == span.PeerPort export",
+			span: Span{Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:9090", "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"}}},
+			exports: true,
+		},
+		{
+			name: fmt.Sprintf("no otel metrics environment sends to %x export", defaultOtlpGRPCPort),
+			span: Span{Type: EventTypeGRPCClient, PeerPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"}}},
+			exports: true,
+		},
+		{
+			name:    fmt.Sprintf("no otel environment sends to anything other the %d doesn't export", defaultOtlpGRPCPort),
+			span:    Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0},
+			exports: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.exports, tt.span.IsExportMetricsSpan())
-			assert.False(t, tt.span.IsExportTracesSpan())
+			assert.Equal(t, tt.exports, tt.span.IsExportMetricsSpan(defaultOtlpGRPCPort))
+			assert.False(t, tt.span.IsExportTracesSpan(defaultOtlpGRPCPort))
 		})
 	}
 
@@ -373,12 +434,71 @@ func TestDetectsOTelExport(t *testing.T) {
 			span:    Span{Type: EventTypeGRPCClient, Method: "GET", Path: "/opentelemetry.proto.collector.trace.v1.TraceService/Export", RequestStart: 100, End: 200, Status: 0},
 			exports: true,
 		},
+		{
+			name: "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL != grpc doesn't export",
+			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_PROTOCOL != grpc doesn't export",
+			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is not a valid endpoint doesn't export",
+			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "notanendpoint"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_ENDPOINT is not a valid endpoint doesn't export",
+			span: Span{Type: EventTypeGRPCClient, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "notanendpoint"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT != span.PeerPort doesn't export",
+			span: Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4317"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_ENDPOINT != span.PeerPort doesn't export",
+			span: Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"}}},
+			exports: false,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT == span.PeerPort export",
+			span: Span{Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:9090"}}},
+			exports: true,
+		},
+		{
+			name: "OTEL_EXPORTER_OTLP_ENDPOINT == span.PeerPort export",
+			span: Span{Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:9090", "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf"}}},
+			exports: true,
+		},
+		{
+			name: fmt.Sprintf("no otel traces environment sends to %d export", defaultOtlpGRPCPort),
+			span: Span{Type: EventTypeGRPCClient, PeerPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf"}}},
+			exports: true,
+		},
+		{
+			name:    fmt.Sprintf("no otel environment sends to anything other the %d doesn't export", defaultOtlpGRPCPort),
+			span:    Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0},
+			exports: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.exports, tt.span.IsExportTracesSpan())
-			assert.False(t, tt.span.IsExportMetricsSpan())
+			assert.Equal(t, tt.exports, tt.span.IsExportTracesSpan(defaultOtlpGRPCPort))
+			assert.False(t, tt.span.IsExportMetricsSpan(defaultOtlpGRPCPort))
 		})
 	}
 }

--- a/pkg/components/ebpf/common/pids_test.go
+++ b/pkg/components/ebpf/common/pids_test.go
@@ -129,12 +129,13 @@ func TestFilter_NewNSLater(t *testing.T) {
 }
 
 func TestFilter_ExportsOTelDetection(t *testing.T) {
+	const defaultOtlpPort = 4317
 	pf := newPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 
 	s := svc.Attrs{}
 	span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/random/server/span", RequestStart: 100, End: 200, Status: 200}
 
-	pf.checkIfExportsOTel(&s, &span)
+	pf.checkIfExportsOTel(&s, &span, defaultOtlpPort)
 	assert.False(t, s.ExportsOTelMetricsSpan())
 	assert.False(t, s.ExportsOTelMetrics())
 	assert.False(t, s.ExportsOTelTraces())
@@ -142,7 +143,7 @@ func TestFilter_ExportsOTelDetection(t *testing.T) {
 	s = svc.Attrs{}
 	span = request.Span{Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/metrics", RequestStart: 100, End: 200, Status: 200}
 
-	pf.checkIfExportsOTel(&s, &span)
+	pf.checkIfExportsOTel(&s, &span, defaultOtlpPort)
 	assert.False(t, s.ExportsOTelMetricsSpan())
 	assert.True(t, s.ExportsOTelMetrics())
 	assert.False(t, s.ExportsOTelTraces())
@@ -150,19 +151,20 @@ func TestFilter_ExportsOTelDetection(t *testing.T) {
 	s = svc.Attrs{}
 	span = request.Span{Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces", RequestStart: 100, End: 200, Status: 200}
 
-	pf.checkIfExportsOTel(&s, &span)
+	pf.checkIfExportsOTel(&s, &span, defaultOtlpPort)
 	assert.False(t, s.ExportsOTelMetricsSpan())
 	assert.False(t, s.ExportsOTelMetrics())
 	assert.True(t, s.ExportsOTelTraces())
 }
 
 func TestFilter_ExportsOTelSpanDetection(t *testing.T) {
+	const defaultOtlpPort = 4317
 	pf := newPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 
 	s := svc.Attrs{}
 	span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/random/server/span", RequestStart: 100, End: 200, Status: 200}
 
-	pf.checkIfExportsOTelSpanMetrics(&s, &span)
+	pf.checkIfExportsOTelSpanMetrics(&s, &span, defaultOtlpPort)
 	assert.False(t, s.ExportsOTelMetricsSpan())
 	assert.False(t, s.ExportsOTelMetrics())
 	assert.False(t, s.ExportsOTelTraces())
@@ -170,7 +172,7 @@ func TestFilter_ExportsOTelSpanDetection(t *testing.T) {
 	s = svc.Attrs{}
 	span = request.Span{Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/metrics", RequestStart: 100, End: 200, Status: 200}
 
-	pf.checkIfExportsOTelSpanMetrics(&s, &span)
+	pf.checkIfExportsOTelSpanMetrics(&s, &span, defaultOtlpPort)
 	assert.False(t, s.ExportsOTelMetricsSpan())
 	assert.False(t, s.ExportsOTelMetrics())
 	assert.False(t, s.ExportsOTelTraces())
@@ -178,11 +180,11 @@ func TestFilter_ExportsOTelSpanDetection(t *testing.T) {
 	s = svc.Attrs{}
 	span = request.Span{Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces", RequestStart: 100, End: 200, Status: 200}
 
-	pf.checkIfExportsOTelSpanMetrics(&s, &span)
+	pf.checkIfExportsOTelSpanMetrics(&s, &span, defaultOtlpPort)
 	assert.False(t, s.ExportsOTelMetrics())
 	assert.True(t, s.ExportsOTelMetricsSpan())
 	assert.False(t, s.ExportsOTelTraces())
-	pf.checkIfExportsOTel(&s, &span)
+	pf.checkIfExportsOTel(&s, &span, defaultOtlpPort)
 	assert.True(t, s.ExportsOTelTraces())
 }
 

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -169,7 +169,8 @@ var DefaultConfig = Config{
 				Metadata: map[string]*services.GlobAttr{"k8s_namespace": &k8sDefaultNamespacesGlob},
 			},
 		},
-		MinProcessAge: 5 * time.Second,
+		MinProcessAge:       5 * time.Second,
+		DefaultOtlpGRPCPort: 4317,
 	},
 	NodeJS: NodeJSConfig{
 		Enabled: true,

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -245,6 +245,7 @@ discovery:
 					Metadata: map[string]*services.GlobAttr{"k8s_namespace": &k8sDefaultNamespacesGlob},
 				},
 			},
+			DefaultOtlpGRPCPort: 4317,
 		},
 		NodeJS: NodeJSConfig{
 			Enabled: true,

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -98,7 +98,7 @@ type DiscoveryConfig struct {
 
 	// DefaultOtlpGRPCPort specifies the default OTLP gRPC port (4317) to fallback on when missing environment variables on service, for
 	// checking for grpc export requests, defaults to 4317
-	DefaultOtlpGRPCPort int `yaml:"default_otlp_grpc_port" env:"OTEL_DEFAULT_OTLP_GRPC_PORT"`
+	DefaultOtlpGRPCPort int `yaml:"default_otlp_grpc_port" env:"OTEL_EBPF_DEFAULT_OTLP_GRPC_PORT"`
 
 	// Min process age to be considered for discovery.
 	//nolint:undoc

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -96,6 +96,10 @@ type DiscoveryConfig struct {
 	// Disables instrumentation of services which are already instrumented
 	ExcludeOTelInstrumentedServices bool `yaml:"exclude_otel_instrumented_services" env:"OTEL_EBPF_EXCLUDE_OTEL_INSTRUMENTED_SERVICES"`
 
+	// DefaultOtlpGRPCPort specifies the default OTLP gRPC port (4317) to fallback on when missing environment variables on service, for
+	// checking for grpc export requests, defaults to 4317
+	DefaultOtlpGRPCPort int `yaml:"default_otlp_grpc_port" env:"OTEL_DEFAULT_OTLP_GRPC_PORT"`
+
 	// Min process age to be considered for discovery.
 	//nolint:undoc
 	MinProcessAge time.Duration `yaml:"min_process_age" env:"OTEL_EBPF_MIN_PROCESS_AGE"`


### PR DESCRIPTION
like we talked about in the sig meeting
- try to detect from env
- if its for sure not GRPC we move on
- if it can be GRPC, we try to extract the port from the endpoint specified in envvars
- if no envvar exist, check for default port specified in config
- check if it equals the span.PeerPort