### PR TITLE
Pgn/batch

### DIFF
--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -2067,9 +2067,15 @@
           ],
           "x-env-var": "OTEL_EBPF_BACKOFF_MAX_INTERVAL"
         },
+        "batch_max_size": {
+          "type": "integer",
+          "description": "BatchMaxSize is the maximum number of spans that the batcher will accumulate before flushing a batch to the sending queue. It also accepts OTEL_EBPF_OTLP_TRACES_MAX_QUEUE_SIZE for backwards compatibility: that env var was historically the batch max size despite its misleading name.",
+          "x-env-var": "OTEL_EBPF_OTLP_TRACES_BATCH_MAX_SIZE"
+        },
         "batch_timeout": {
           "type": "string",
           "pattern": "^[0-9]+(ms|s|m)$",
+          "description": "BatchTimeout is the time after which a batch will be sent regardless of its size.",
           "examples": [
             "30s",
             "5m",
@@ -2113,8 +2119,8 @@
         },
         "max_queue_size": {
           "type": "integer",
-          "description": "Configuration options below this line will remain undocumented at the moment, but can be useful for performance-tuning of some customers.",
-          "x-env-var": "OTEL_EBPF_OTLP_TRACES_MAX_QUEUE_SIZE"
+          "description": "DeprecatedMaxQueueSize accepts the legacy `max_queue_size` YAML key for backwards compatibility. It is copied into BatchMaxSize by NormalizeQueueConfig with a deprecation warning. Do not read this field directly; use BatchMaxSize. The env var equivalent is handled transparently via the envDefault expansion on BatchMaxSize above.",
+          "x-env-var": "-"
         },
         "otel_sdk_log_level": {
           "type": "string",
@@ -2131,6 +2137,11 @@
             "http/protobuf"
           ],
           "x-env-var": "OTEL_EXPORTER_OTLP_PROTOCOL"
+        },
+        "queue_size": {
+          "type": "integer",
+          "description": "QueueSize is the maximum number of spans that the sending queue will hold before applying back-pressure. It must be >= BatchMaxSize, otherwise the memory queue rejects every batch with \"element size too large\" and drops spans permanently. If left at 0 it defaults to 4 * BatchMaxSize.",
+          "x-env-var": "OTEL_EBPF_OTLP_TRACES_QUEUE_SIZE"
         },
         "reporters_cache_len": {
           "type": "integer",

--- a/pkg/appolly/instrumenter_test.go
+++ b/pkg/appolly/instrumenter_test.go
@@ -166,7 +166,8 @@ func TestTracerPipeline(t *testing.T) {
 	gb := newGraphBuilder(&obi.Config{
 		Traces: otelcfg.TracesConfig{
 			BatchTimeout:      10 * time.Millisecond,
-			MaxQueueSize:      10,
+			BatchMaxSize:      10,
+			QueueSize:         40,
 			TracesEndpoint:    tc.ServerEndpoint,
 			ReportersCacheLen: 16,
 			Instrumentations:  []instrumentations.Instrumentation{instrumentations.InstrumentationALL},
@@ -211,7 +212,8 @@ func TestMergedMetricsTracePipeline(t *testing.T) {
 	}
 	tCfg := otelcfg.TracesConfig{
 		BatchTimeout:      10 * time.Millisecond,
-		MaxQueueSize:      10,
+		BatchMaxSize:      10,
+		QueueSize:         40,
 		TracesEndpoint:    tc.ServerEndpoint,
 		ReportersCacheLen: 16,
 		Instrumentations:  []instrumentations.Instrumentation{instrumentations.InstrumentationALL},

--- a/pkg/export/otel/otelcfg/config_traces.go
+++ b/pkg/export/otel/otelcfg/config_traces.go
@@ -38,9 +38,26 @@ type TracesConfig struct {
 
 	SamplerConfig services.SamplerConfig `yaml:"sampler"`
 
-	// Configuration options below this line will remain undocumented at the moment,
-	// but can be useful for performance-tuning of some customers.
-	MaxQueueSize int           `yaml:"max_queue_size" env:"OTEL_EBPF_OTLP_TRACES_MAX_QUEUE_SIZE"`
+	// BatchMaxSize is the maximum number of spans that the batcher will accumulate
+	// before flushing a batch to the sending queue.
+	// It also accepts OTEL_EBPF_OTLP_TRACES_MAX_QUEUE_SIZE for backwards compatibility:
+	// that env var was historically the batch max size despite its misleading name.
+	BatchMaxSize int `yaml:"batch_max_size" env:"OTEL_EBPF_OTLP_TRACES_BATCH_MAX_SIZE,expand" envDefault:"${OTEL_EBPF_OTLP_TRACES_MAX_QUEUE_SIZE}"`
+
+	// DeprecatedMaxQueueSize accepts the legacy `max_queue_size` YAML key for
+	// backwards compatibility. It is copied into BatchMaxSize by
+	// NormalizeQueueConfig with a deprecation warning. Do not read this field
+	// directly; use BatchMaxSize. The env var equivalent is handled
+	// transparently via the envDefault expansion on BatchMaxSize above.
+	DeprecatedMaxQueueSize int `yaml:"max_queue_size" env:"-"`
+
+	// QueueSize is the maximum number of spans that the sending queue will hold
+	// before applying back-pressure. It must be >= BatchMaxSize, otherwise the
+	// memory queue rejects every batch with "element size too large" and drops
+	// spans permanently. If left at 0 it defaults to 4 * BatchMaxSize.
+	QueueSize int `yaml:"queue_size" env:"OTEL_EBPF_OTLP_TRACES_QUEUE_SIZE"`
+
+	// BatchTimeout is the time after which a batch will be sent regardless of its size.
 	BatchTimeout time.Duration `yaml:"batch_timeout" env:"OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT"`
 
 	// Configuration options for BackOffConfig of the traces exporter.
@@ -66,9 +83,31 @@ type TracesConfig struct {
 	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
 }
 
+func (m *TracesConfig) NormalizeQueueConfig() error {
+	if m.BatchMaxSize == 0 && m.DeprecatedMaxQueueSize > 0 {
+		tlog().Warn("traces.max_queue_size is deprecated, use traces.batch_max_size instead",
+			"value", m.DeprecatedMaxQueueSize)
+		m.BatchMaxSize = m.DeprecatedMaxQueueSize
+	}
+	if m.QueueSize == 0 && m.BatchMaxSize > 0 {
+		// Queue capacity must be at least 2x max batch size to prevent "element size too large"
+		// errors and permanent data loss. We use a 4x multiplier to provide headroom for
+		// transient latency spikes, ensuring brief collector slowdowns don't immediately
+		// back-pressure the eBPF reader.
+		m.QueueSize = 4 * m.BatchMaxSize
+	}
+	if m.BatchMaxSize > 0 && m.QueueSize < m.BatchMaxSize {
+		return fmt.Errorf("traces.queue_size (%d) must be >= traces.batch_max_size (%d): "+
+			"otherwise the sending queue rejects every batch with \"element size too large\"",
+			m.QueueSize, m.BatchMaxSize)
+	}
+	return nil
+}
+
 func (m TracesConfig) MarshalYAML() (any, error) {
 	omit := map[string]struct{}{
-		"endpoint": {},
+		"endpoint":       {},
+		"max_queue_size": {},
 	}
 	return omitFieldsForYAML(m, omit), nil
 }

--- a/pkg/export/otel/otelcfg/config_traces.go
+++ b/pkg/export/otel/otelcfg/config_traces.go
@@ -95,6 +95,8 @@ func (m *TracesConfig) NormalizeQueueConfig() error {
 		// transient latency spikes, ensuring brief collector slowdowns don't immediately
 		// back-pressure the eBPF reader.
 		m.QueueSize = 4 * m.BatchMaxSize
+		tlog().Info("traces.queue_size not set, defaulting to 4 * batch_max_size",
+			"queue_size", m.QueueSize, "batch_max_size", m.BatchMaxSize)
 	}
 	if m.BatchMaxSize > 0 && m.QueueSize < m.BatchMaxSize {
 		return fmt.Errorf("traces.queue_size (%d) must be >= traces.batch_max_size (%d): "+

--- a/pkg/export/otel/otelcfg/config_traces_test.go
+++ b/pkg/export/otel/otelcfg/config_traces_test.go
@@ -8,8 +8,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/caarlos0/env/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 )
@@ -317,4 +319,88 @@ func TestTracesConfig_Enabled(t *testing.T) {
 
 func TestTracesConfig_Disabled(t *testing.T) {
 	assert.False(t, (&TracesConfig{}).Enabled())
+}
+
+func TestNormalizeQueueConfig(t *testing.T) {
+	t.Run("legacy max_queue_size copied to BatchMaxSize and QueueSize defaulted", func(t *testing.T) {
+		cfg := &TracesConfig{DeprecatedMaxQueueSize: 100}
+		require.NoError(t, cfg.NormalizeQueueConfig())
+		assert.Equal(t, 100, cfg.BatchMaxSize)
+		assert.Equal(t, 400, cfg.QueueSize)
+	})
+
+	t.Run("BatchMaxSize set, QueueSize defaults to 4x", func(t *testing.T) {
+		cfg := &TracesConfig{BatchMaxSize: 50}
+		require.NoError(t, cfg.NormalizeQueueConfig())
+		assert.Equal(t, 50, cfg.BatchMaxSize)
+		assert.Equal(t, 200, cfg.QueueSize)
+	})
+
+	t.Run("BatchMaxSize takes precedence over deprecated field", func(t *testing.T) {
+		cfg := &TracesConfig{BatchMaxSize: 10, DeprecatedMaxQueueSize: 999}
+		require.NoError(t, cfg.NormalizeQueueConfig())
+		assert.Equal(t, 10, cfg.BatchMaxSize)
+		assert.Equal(t, 40, cfg.QueueSize)
+	})
+
+	t.Run("explicit QueueSize is respected", func(t *testing.T) {
+		cfg := &TracesConfig{BatchMaxSize: 10, QueueSize: 500}
+		require.NoError(t, cfg.NormalizeQueueConfig())
+		assert.Equal(t, 500, cfg.QueueSize)
+	})
+
+	t.Run("error when QueueSize < BatchMaxSize", func(t *testing.T) {
+		cfg := &TracesConfig{BatchMaxSize: 100, QueueSize: 10}
+		err := cfg.NormalizeQueueConfig()
+		require.Error(t, err)
+	})
+
+	t.Run("zero values produce no error and no defaults", func(t *testing.T) {
+		cfg := &TracesConfig{}
+		require.NoError(t, cfg.NormalizeQueueConfig())
+		assert.Equal(t, 0, cfg.BatchMaxSize)
+		assert.Equal(t, 0, cfg.QueueSize)
+	})
+}
+
+func TestNormalizeQueueConfig_LegacyYAML(t *testing.T) {
+	yamlBytes := []byte("max_queue_size: 250\n")
+	var cfg TracesConfig
+	require.NoError(t, yaml.Unmarshal(yamlBytes, &cfg))
+	assert.Equal(t, 250, cfg.DeprecatedMaxQueueSize)
+	assert.Equal(t, 0, cfg.BatchMaxSize)
+
+	require.NoError(t, cfg.NormalizeQueueConfig())
+	assert.Equal(t, 250, cfg.BatchMaxSize)
+	assert.Equal(t, 1000, cfg.QueueSize)
+}
+
+func TestNormalizeQueueConfig_LegacyEnvVar(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	t.Setenv("OTEL_EBPF_OTLP_TRACES_MAX_QUEUE_SIZE", "300")
+
+	var cfg TracesConfig
+	require.NoError(t, env.Parse(&cfg))
+	// The legacy env var is wired into BatchMaxSize via envDefault expansion.
+	assert.Equal(t, 300, cfg.BatchMaxSize)
+
+	require.NoError(t, cfg.NormalizeQueueConfig())
+	assert.Equal(t, 300, cfg.BatchMaxSize)
+	assert.Equal(t, 1200, cfg.QueueSize)
+}
+
+func TestNormalizeQueueConfig_NewEnvVarOverridesLegacy(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	t.Setenv("OTEL_EBPF_OTLP_TRACES_MAX_QUEUE_SIZE", "300")
+	t.Setenv("OTEL_EBPF_OTLP_TRACES_BATCH_MAX_SIZE", "75")
+	t.Setenv("OTEL_EBPF_OTLP_TRACES_QUEUE_SIZE", "600")
+
+	var cfg TracesConfig
+	require.NoError(t, env.Parse(&cfg))
+	assert.Equal(t, 75, cfg.BatchMaxSize)
+	assert.Equal(t, 600, cfg.QueueSize)
+
+	require.NoError(t, cfg.NormalizeQueueConfig())
+	assert.Equal(t, 75, cfg.BatchMaxSize)
+	assert.Equal(t, 600, cfg.QueueSize)
 }

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -301,32 +301,29 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 
 func getQueueConfig(cfg otelcfg.TracesConfig) configoptional.Optional[exporterhelper.QueueBatchConfig] {
 	// enable batching only if the queue config is enabled
-	if cfg.MaxQueueSize <= 0 && cfg.BatchTimeout <= 0 {
+	if cfg.BatchMaxSize <= 0 && cfg.BatchTimeout <= 0 {
 		return configoptional.None[exporterhelper.QueueBatchConfig]()
 	}
+
 	queueConfig := exporterhelper.NewDefaultQueueConfig()
 	queueConfig.Sizer = exporterhelper.RequestSizerTypeItems
 	// Avoid continuously seeing "sending queue is full" errors in the standard output
 	queueConfig.BlockOnOverflow = true
+	if cfg.QueueSize > 0 {
+		queueConfig.QueueSize = int64(cfg.QueueSize)
+	}
 	batchCfg := exporterhelper.BatchConfig{
 		Sizer: queueConfig.Sizer,
 	}
 	batchSet := false
-	if cfg.MaxQueueSize > 0 {
+	if cfg.BatchMaxSize > 0 {
 		batchSet = true
-		batchCfg.MaxSize = int64(cfg.MaxQueueSize)
-		// Queue capacity must be at least 2x max batch size to prevent "element size too large"
-		// errors and permanent data loss. We use a 4x multiplier to provide headroom for
-		// transient latency spikes, ensuring brief collector slowdowns don't immediately
-		// back-pressure the eBPF reader.
-		if minQueue := int64(cfg.MaxQueueSize) * 4; queueConfig.QueueSize < minQueue {
-			queueConfig.QueueSize = minQueue
-		}
+		batchCfg.MaxSize = int64(cfg.BatchMaxSize)
 	}
 	if cfg.BatchTimeout > 0 {
 		batchSet = true
 		batchCfg.FlushTimeout = cfg.BatchTimeout
-		batchCfg.MinSize = int64(cfg.MaxQueueSize)
+		batchCfg.MinSize = int64(cfg.BatchMaxSize)
 	}
 	if batchSet {
 		queueConfig.Batch = configoptional.Some(batchCfg)

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -215,7 +215,8 @@ var DefaultConfig = Config{
 	Traces: otelcfg.TracesConfig{
 		Protocol:          otelcfg.ProtocolUnset,
 		TracesProtocol:    otelcfg.ProtocolUnset,
-		MaxQueueSize:      4096,
+		BatchMaxSize:      4096,
+		QueueSize:         16384,
 		BatchTimeout:      15 * time.Second,
 		ReportersCacheLen: ReporterLRUSize,
 		Instrumentations: []instrumentations.Instrumentation{
@@ -610,6 +611,10 @@ func (c *Config) Validate() error {
 	}
 
 	if err := c.Discovery.Validate(); err != nil {
+		return ConfigError(err.Error())
+	}
+
+	if err := c.Traces.NormalizeQueueConfig(); err != nil {
 		return ConfigError(err.Error())
 	}
 

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -218,7 +218,8 @@ discovery:
 			Protocol:          otelcfg.ProtocolUnset,
 			CommonEndpoint:    "localhost:3131",
 			TracesEndpoint:    "localhost:3232",
-			MaxQueueSize:      4096,
+			BatchMaxSize:      4096,
+			QueueSize:         16384,
 			BatchTimeout:      15 * time.Second,
 			ReportersCacheLen: ReporterLRUSize,
 			Instrumentations: []instrumentations.Instrumentation{


### PR DESCRIPTION
## Summary

This PR adds `BatchMaxSize` and `QueueSize` fields and deprecates `max_queue_size`, it still allows to set it for backwards-compatibility. Basically we were doing `batchCfg.MaxSize = int64(cfg.MaxQueueSize)` which it's misleading and now we are doing `batchCfg.MaxSize = int64(cfg.BatchMaxSize)`.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->