### PR TITLE
Load only needed probes in StatsO11y

### DIFF
--- a/devdocs/metrics.md
+++ b/devdocs/metrics.md
@@ -104,9 +104,13 @@ To add a new metric, follow these guidelines:
 1. Decide on the hook point where you want to attach the eBPF probe. For example, you can use a kprobe on the `tcp_close` function to retrieve `srtt_us`.
 2. Add a unique flag that indicates an event related to the metric you want to calculate in [bpf/statsolly/types.h](../bpf/statsolly/types.h) and the corresponding Go constant in [stat.go](../pkg/internal/statsolly/ebpf/stat.go), for example, `k_event_stat_tcp_rtt` and `StatTypeTCPRtt`.
 3. Add the eBPF probe to the [bpf/statsolly](../bpf/statsolly/) folder. Here, the metric will be calculated and sent to userspace using the `stats_events` ringbuffer.
-4. In the [tracer_ringbuf.go](../pkg/internal/statsolly/stats/tracer_ringbuf.go), simply add a function that handles that metric. This function will convert the event to a `ebpf.Stat`.
-5. Then, modify the `Stat` struct accordingly, by adding a data structure containing all the necessary fields. For example `TCPRtt` struct.
-6. The only thing left is to create the appropriate data structures in the `Prometheus` and `OTEL` exporters by adding the appropriate attributes. Each exporter owns one observe-method per stat type (e.g. `observeTCPRtt`, `observeTCPFailedConnections`) that translates the `ebpf.Stat` into a given observation.
+4. Wire the probe into [stats_tracer.go](../pkg/internal/statsolly/ebpf/stats_tracer.go):
+    - add a program-name constant (e.g. `progObiKprobeTcpCloseSrtt`) matching the C symbol;
+    - add a hook-point constant (kernel function name for kprobes, `group/name` for tracepoints);
+    - add an entry to the appropriate `kprobes` or `tracepoints` slice inside `NewStatsFetcher`, with `enabled` driven by the corresponding `features.StatsXxx()` predicate. Disabled probes are deleted from the spec before load, so they never enter the kernel.
+5. In the [tracer_ringbuf.go](../pkg/internal/statsolly/stats/tracer_ringbuf.go), simply add a function that handles that metric. This function will convert the event to a `ebpf.Stat`.
+6. Then, modify the `Stat` struct accordingly, by adding a data structure containing all the necessary fields. For example `TCPRtt` struct.
+7. The only thing left is to create the appropriate data structures in the `Prometheus` and `OTEL` exporters by adding the appropriate attributes. Each exporter owns one observe-method per stat type (e.g. `observeTCPRtt`, `observeTCPFailedConnections`) that translates the `ebpf.Stat` into a given observation.
 
     - `statMetricsReporter` in [pkg/export/prom/prom_stats.go](../pkg/export/prom/prom_stats.go) for Prometheus
     - `statMetricsExporter` in [pkg/export/otel/metrics_stats.go](../pkg/export/otel/metrics_stats.go) for OTEL

--- a/pkg/internal/ebpf/convenience/convenience.go
+++ b/pkg/internal/ebpf/convenience/convenience.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 
@@ -99,6 +100,58 @@ func LoadSpec(spec *ebpf.CollectionSpec, objects any, constants map[string]any, 
 	}
 
 	return nil
+}
+
+// pruneToEnabled removes from spec.Programs any program whose name is not in
+// the enabled set. To keep every program in the spec, callers must pass the
+// full list of program names — there is no special-cased "keep all" value, so
+// an empty slice unambiguously drops everything.
+func pruneToEnabled(spec *ebpf.CollectionSpec, enabled []string) {
+	for name := range spec.Programs {
+		if !slices.Contains(enabled, name) {
+			delete(spec.Programs, name)
+		}
+	}
+}
+
+// LoadPartial behaves like LoadSpec but loads via NewCollectionWithOptions
+// instead of LoadAndAssign, returning the *ebpf.Collection so the caller can
+// pick programs and maps off it by name (typical use: per-probe attach loops
+// where only a subset of programs is enabled at runtime).
+//
+// Programs whose name is not in enabledPrograms are removed from spec.Programs
+// before load and never enter the kernel. To keep every program, pass the full
+// list of program names; an empty slice drops everything.
+//
+// The caller owns the returned *ebpf.Collection: detach the maps/programs it
+// needs, then Close() to free the rest.
+//
+// Notes about other parameters match LoadSpec:
+// - constants: optional map of BPF constants to rewrite (may be nil)
+// - sharedMaps: map store for PinInternal maps, shared across specs within the same agent
+// - pinPath: bpffs pin path for PinByName maps (empty string to skip)
+func LoadPartial(spec *ebpf.CollectionSpec, enabledPrograms []string, constants map[string]any, sharedMaps map[string]*ebpf.Map, mu *sync.Mutex, pinPath string) (*ebpf.Collection, error) {
+	pruneToEnabled(spec, enabledPrograms)
+
+	if constants != nil {
+		if err := RewriteConstants(spec, constants); err != nil {
+			return nil, fmt.Errorf("rewriting BPF constants: %w", err)
+		}
+	}
+
+	collOpts, err := ResolveMaps(spec, sharedMaps, mu)
+	if err != nil {
+		return nil, fmt.Errorf("resolving maps: %w", err)
+	}
+
+	collOpts.Programs = ebpf.ProgramOptions{LogSizeStart: 640 * 1024}
+	collOpts.Maps = ebpf.MapOptions{PinPath: pinPath}
+
+	coll, err := ebpf.NewCollectionWithOptions(spec, *collOpts)
+	if err != nil {
+		return nil, fmt.Errorf("loading BPF collection: %w", err)
+	}
+	return coll, nil
 }
 
 const (

--- a/pkg/internal/ebpf/convenience/convenience_test.go
+++ b/pkg/internal/ebpf/convenience/convenience_test.go
@@ -40,6 +40,44 @@ func makeSpec(maps map[string]*ebpf.MapSpec) *ebpf.CollectionSpec {
 	return &ebpf.CollectionSpec{Maps: maps}
 }
 
+func TestPruneToEnabled(t *testing.T) {
+	makeProgs := func() map[string]*ebpf.ProgramSpec {
+		return map[string]*ebpf.ProgramSpec{
+			"prog_a": {Name: "prog_a"},
+			"prog_b": {Name: "prog_b"},
+			"prog_c": {Name: "prog_c"},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		enabled []string
+		want    []string // remaining program names
+	}{
+		{name: "full list keeps all", enabled: []string{"prog_a", "prog_b", "prog_c"}, want: []string{"prog_a", "prog_b", "prog_c"}},
+		{name: "nil drops all", enabled: nil, want: nil},
+		{name: "empty drops all", enabled: []string{}, want: nil},
+		{name: "subset", enabled: []string{"prog_a", "prog_c"}, want: []string{"prog_a", "prog_c"}},
+		{name: "unknown name ignored", enabled: []string{"prog_a", "missing"}, want: []string{"prog_a"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := &ebpf.CollectionSpec{Programs: makeProgs()}
+			pruneToEnabled(spec, tc.enabled)
+
+			if len(spec.Programs) != len(tc.want) {
+				t.Fatalf("got %d programs, want %d (%v)", len(spec.Programs), len(tc.want), tc.want)
+			}
+			for _, name := range tc.want {
+				if _, ok := spec.Programs[name]; !ok {
+					t.Errorf("expected program %q to remain", name)
+				}
+			}
+		})
+	}
+}
+
 func TestSetupMapSizes_ScaleUp(t *testing.T) {
 	spec := makeSpec(map[string]*ebpf.MapSpec{
 		"my_hash": {Type: ebpf.Hash, MaxEntries: 1024},

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/rlimit"
 
@@ -29,9 +28,10 @@ type (
 )
 
 type probe struct {
-	name    string
-	program *ebpf.Program
-	enabled bool
+	progName string
+	hookName string
+	enabled  bool
+	out      **ebpf.Program
 }
 
 // Hook point names, grouped by attach type.
@@ -41,6 +41,18 @@ const (
 
 	// Tracepoints: group/name.
 	TracepointInetSockSetState = "sock/inet_sock_set_state"
+)
+
+// Probe names
+const (
+	ObiKprobeTcpCloseSrtt         = "obi_kprobe_tcp_close_srtt"
+	ObiTracepointInetSockSetState = "obi_tracepoint_inet_sock_set_state"
+)
+
+// Map names
+const (
+	StatsEvents = "stats_events"
+	DebugEvents = "debug_events"
 )
 
 // $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
@@ -63,74 +75,121 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 			"error", err)
 	}
 
-	objects := StatsObjects{}
 	spec, err := LoadStats()
 	if err != nil {
 		return nil, fmt.Errorf("loading BPF data: %w", err)
 	}
 
-	fixupSpec(spec, features)
+	objects := &StatsObjects{}
+
+	// Probe metadata, grouped by attach type. Each slice drives both spec
+	// deletion (so disabled probes never enter the kernel) and the per-type
+	// attach loop below.
+	//
+	// Do not use LoadSpec from the convenience pkg because we need
+	// NewCollectionWithOptions instead of LoadAndAssign for this use case.
+	kprobes := []probe{
+		{
+			progName: ObiKprobeTcpCloseSrtt,
+			hookName: KprobeTCPClose,
+			enabled:  features.StatsTCPRtt(),
+			out:      &objects.ObiKprobeTcpCloseSrtt,
+		},
+	}
+	tracepoints := []probe{
+		{
+			progName: ObiTracepointInetSockSetState,
+			hookName: TracepointInetSockSetState,
+			enabled:  features.StatsTCPFailedConnections(),
+			out:      &objects.ObiTracepointInetSockSetState,
+		},
+	}
+
+	// Drop programs the user disabled so NewCollectionWithOptions won't load them.
+	for _, p := range kprobes {
+		if !p.enabled {
+			delete(spec.Programs, p.progName)
+		}
+	}
+	for _, p := range tracepoints {
+		if !p.enabled {
+			delete(spec.Programs, p.progName)
+		}
+	}
+
+	if err := ebpfconvenience.RewriteConstants(spec, map[string]any{
+		"g_bpf_debug": cfg.BpfDebug,
+	}); err != nil {
+		return nil, fmt.Errorf("rewriting BPF constants: %w", err)
+	}
 
 	ebpfconvenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor)
 
 	sharedMaps := map[string]*ebpf.Map{}
 	var mu sync.Mutex
-	if err := ebpfconvenience.LoadSpec(spec, &objects, map[string]any{
-		"g_bpf_debug": cfg.BpfDebug,
-	}, sharedMaps, &mu, ""); err != nil {
-		return nil, fmt.Errorf("loading stats eBPF spec: %w", err)
+	collOpts, err := ebpfconvenience.ResolveMaps(spec, sharedMaps, &mu)
+	if err != nil {
+		return nil, fmt.Errorf("resolving maps: %w", err)
+	}
+	collOpts.Programs = ebpf.ProgramOptions{LogSizeStart: 640 * 1024}
+	// collOpts.Maps.PinPath stays zero; statsolly passes "" today.
+
+	coll, err := ebpf.NewCollectionWithOptions(spec, *collOpts)
+	if err != nil {
+		return nil, fmt.Errorf("loading stats eBPF collection: %w", err)
 	}
 
-	var closables []io.Closer
+	objects.StatsEvents = coll.DetachMap(StatsEvents)
+	objects.DebugEvents = coll.DetachMap(DebugEvents)
+
+	closables := []io.Closer{objects}
 
 	// kprobes
-	for _, k := range []probe{
-		{
-			name:    KprobeTCPClose,
-			program: objects.ObiKprobeTcpCloseSrtt,
-			enabled: features.StatsTCPRtt(),
-		},
-	} {
-		if !k.enabled {
+	for _, k := range kprobes {
+		prog := coll.DetachProgram(k.progName)
+		if prog == nil {
 			continue
 		}
+		*k.out = prog
 
-		l, err := link.Kprobe(k.name, k.program, nil)
+		l, err := link.Kprobe(k.hookName, prog, nil)
 		if err != nil {
 			closeAll(closables)
-			return nil, fmt.Errorf("failed kprobe attachment %s: %w", k.name, err)
+			coll.Close()
+			return nil, fmt.Errorf("failed kprobe attachment %s: %w", k.hookName, err)
 		}
 		closables = append(closables, l)
 	}
 
 	// tracepoints
-	for _, t := range []probe{
-		{
-			name:    TracepointInetSockSetState,
-			program: objects.ObiTracepointInetSockSetState,
-			enabled: features.StatsTCPFailedConnections(),
-		},
-	} {
-		if !t.enabled {
+	for _, t := range tracepoints {
+		prog := coll.DetachProgram(t.progName)
+		if prog == nil {
 			continue
 		}
+		*t.out = prog
 
-		parts := strings.SplitN(t.name, "/", 2)
-		if len(parts) != 2 {
+		group, tp, ok := strings.Cut(t.hookName, "/")
+		if !ok {
 			closeAll(closables)
-			return nil, fmt.Errorf("invalid tracepoint %q: must be group/name", t.name)
+			coll.Close()
+			return nil, fmt.Errorf("invalid tracepoint %q: must be group/name", t.hookName)
 		}
-		l, err := link.Tracepoint(parts[0], parts[1], t.program, nil)
+		l, err := link.Tracepoint(group, tp, prog, nil)
 		if err != nil {
 			closeAll(closables)
-			return nil, fmt.Errorf("failed tracepoint attachment %s: %w", t.name, err)
+			coll.Close()
+			return nil, fmt.Errorf("failed tracepoint attachment %s: %w", t.hookName, err)
 		}
 		closables = append(closables, l)
 	}
 
+	// detached entries are no-ops; frees anything we didn't claim.
+	coll.Close()
+
 	return &StatsFetcher{
 		log:       tlog,
-		objects:   &objects,
+		objects:   objects,
 		closables: closables,
 	}, nil
 }
@@ -164,29 +223,4 @@ func (m *StatsFetcher) StatsEventsMap() *ebpf.Map {
 
 func (m *StatsFetcher) DebugEventsMap() *ebpf.Map {
 	return m.objects.DebugEvents
-}
-
-func fixupSpec(spec *ebpf.CollectionSpec, features *export.Features) {
-	if !features.StatsTCPFailedConnections() {
-		spec.Programs["obi_tracepoint_inet_sock_set_state"] = &ebpf.ProgramSpec{
-			Name: "obi_dummy_statsolly_tp",
-			Type: ebpf.TracePoint,
-			Instructions: asm.Instructions{
-				asm.Mov.Imm(asm.R0, 0),
-				asm.Return(),
-			},
-			License: "Dual MIT/GPL",
-		}
-	}
-	if !features.StatsTCPRtt() {
-		spec.Programs["obi_kprobe_tcp_close_srtt"] = &ebpf.ProgramSpec{
-			Name: "obi_dummy_statsolly_kp",
-			Type: ebpf.Kprobe,
-			Instructions: asm.Instructions{
-				asm.Mov.Imm(asm.R0, 0),
-				asm.Return(),
-			},
-			License: "Dual MIT/GPL",
-		}
-	}
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -68,6 +68,9 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 		return nil, fmt.Errorf("loading BPF data: %w", err)
 	}
 
+	// pino test, delete one fixes probe
+	delete(spec.Programs, "obi_tracepoint_inet_sock_set_state") // drop failed-conn
+
 	ebpfconvenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor)
 
 	sharedMaps := map[string]*ebpf.Map{}

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -43,16 +43,16 @@ const (
 	TracepointInetSockSetState = "sock/inet_sock_set_state"
 )
 
-// Probe names
+// program names
 const (
-	ObiKprobeTcpCloseSrtt         = "obi_kprobe_tcp_close_srtt"
-	ObiTracepointInetSockSetState = "obi_tracepoint_inet_sock_set_state"
+	progObiKprobeTcpCloseSrtt         = "obi_kprobe_tcp_close_srtt"
+	progObiTracepointInetSockSetState = "obi_tracepoint_inet_sock_set_state"
 )
 
 // Map names
 const (
-	StatsEvents = "stats_events"
-	DebugEvents = "debug_events"
+	mapStatsEvents = "stats_events"
+	mapDebugEvents = "debug_events"
 )
 
 // $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
@@ -90,7 +90,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 	// NewCollectionWithOptions instead of LoadAndAssign for this use case.
 	kprobes := []probe{
 		{
-			progName: ObiKprobeTcpCloseSrtt,
+			progName: progObiKprobeTcpCloseSrtt,
 			hookName: KprobeTCPClose,
 			enabled:  features.StatsTCPRtt(),
 			out:      &objects.ObiKprobeTcpCloseSrtt,
@@ -98,7 +98,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 	}
 	tracepoints := []probe{
 		{
-			progName: ObiTracepointInetSockSetState,
+			progName: progObiTracepointInetSockSetState,
 			hookName: TracepointInetSockSetState,
 			enabled:  features.StatsTCPFailedConnections(),
 			out:      &objects.ObiTracepointInetSockSetState,
@@ -106,16 +106,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 	}
 
 	// Drop programs the user disabled so NewCollectionWithOptions won't load them.
-	for _, p := range kprobes {
-		if !p.enabled {
-			delete(spec.Programs, p.progName)
-		}
-	}
-	for _, p := range tracepoints {
-		if !p.enabled {
-			delete(spec.Programs, p.progName)
-		}
-	}
+	dropDisabledPrograms(spec, kprobes, tracepoints)
 
 	if err := ebpfconvenience.RewriteConstants(spec, map[string]any{
 		"g_bpf_debug": cfg.BpfDebug,
@@ -125,6 +116,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 
 	ebpfconvenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor)
 
+	// statsolly intentionally doesn't share maps with other specs
 	sharedMaps := map[string]*ebpf.Map{}
 	var mu sync.Mutex
 	collOpts, err := ebpfconvenience.ResolveMaps(spec, sharedMaps, &mu)
@@ -138,24 +130,35 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 	if err != nil {
 		return nil, fmt.Errorf("loading stats eBPF collection: %w", err)
 	}
+	// Frees any programs/maps not claimed via DetachMap/DetachProgram below
+	defer coll.Close()
 
-	objects.StatsEvents = coll.DetachMap(StatsEvents)
-	objects.DebugEvents = coll.DetachMap(DebugEvents)
+	objects.StatsEvents = coll.DetachMap(mapStatsEvents)
+	if objects.StatsEvents == nil {
+		return nil, fmt.Errorf("map %q not found in collection", mapStatsEvents)
+	}
+	objects.DebugEvents = coll.DetachMap(mapDebugEvents)
+	if objects.DebugEvents == nil {
+		return nil, fmt.Errorf("map %q not found in collection", mapDebugEvents)
+	}
 
 	closables := []io.Closer{objects}
 
 	// kprobes
 	for _, k := range kprobes {
+		if !k.enabled {
+			continue
+		}
 		prog := coll.DetachProgram(k.progName)
 		if prog == nil {
-			continue
+			closeAll(closables)
+			return nil, fmt.Errorf("enabled kprobe program %q not found in collection", k.progName)
 		}
 		*k.out = prog
 
 		l, err := link.Kprobe(k.hookName, prog, nil)
 		if err != nil {
 			closeAll(closables)
-			coll.Close()
 			return nil, fmt.Errorf("failed kprobe attachment %s: %w", k.hookName, err)
 		}
 		closables = append(closables, l)
@@ -163,35 +166,46 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 
 	// tracepoints
 	for _, t := range tracepoints {
+		if !t.enabled {
+			continue
+		}
 		prog := coll.DetachProgram(t.progName)
 		if prog == nil {
-			continue
+			closeAll(closables)
+			return nil, fmt.Errorf("enabled tracepoint program %q not found in collection", t.progName)
 		}
 		*t.out = prog
 
 		group, tp, ok := strings.Cut(t.hookName, "/")
 		if !ok {
 			closeAll(closables)
-			coll.Close()
 			return nil, fmt.Errorf("invalid tracepoint %q: must be group/name", t.hookName)
 		}
 		l, err := link.Tracepoint(group, tp, prog, nil)
 		if err != nil {
 			closeAll(closables)
-			coll.Close()
 			return nil, fmt.Errorf("failed tracepoint attachment %s: %w", t.hookName, err)
 		}
 		closables = append(closables, l)
 	}
-
-	// detached entries are no-ops; frees anything we didn't claim.
-	coll.Close()
 
 	return &StatsFetcher{
 		log:       tlog,
 		objects:   objects,
 		closables: closables,
 	}, nil
+}
+
+// dropDisabledPrograms removes from spec.Programs any probe whose enabled flag
+// is false, so NewCollectionWithOptions does not load it into the kernel.
+func dropDisabledPrograms(spec *ebpf.CollectionSpec, probeGroups ...[]probe) {
+	for _, group := range probeGroups {
+		for _, p := range group {
+			if !p.enabled {
+				delete(spec.Programs, p.progName)
+			}
+		}
+	}
 }
 
 func closeAll(closables []io.Closer) {

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -31,7 +31,7 @@ type probe struct {
 	progName string
 	hookName string
 	enabled  bool
-	out      **ebpf.Program
+	out      func(*ebpf.Program)
 }
 
 // Hook point names, grouped by attach type.
@@ -90,7 +90,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 			progName: progObiKprobeTcpCloseSrtt,
 			hookName: KprobeTCPClose,
 			enabled:  features.StatsTCPRtt(),
-			out:      &objects.ObiKprobeTcpCloseSrtt,
+			out:      func(p *ebpf.Program) { objects.ObiKprobeTcpCloseSrtt = p },
 		},
 	}
 	tracepoints := []probe{
@@ -98,7 +98,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 			progName: progObiTracepointInetSockSetState,
 			hookName: TracepointInetSockSetState,
 			enabled:  features.StatsTCPFailedConnections(),
-			out:      &objects.ObiTracepointInetSockSetState,
+			out:      func(p *ebpf.Program) { objects.ObiTracepointInetSockSetState = p },
 		},
 	}
 
@@ -144,7 +144,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 			closeAll(closables)
 			return nil, fmt.Errorf("enabled kprobe program %q not found in collection", k.progName)
 		}
-		*k.out = prog
+		k.out(prog)
 
 		l, err := link.Kprobe(k.hookName, prog, nil)
 		if err != nil {
@@ -164,7 +164,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 			closeAll(closables)
 			return nil, fmt.Errorf("enabled tracepoint program %q not found in collection", t.progName)
 		}
-		*t.out = prog
+		t.out(prog)
 
 		group, tp, ok := strings.Cut(t.hookName, "/")
 		if !ok {

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -43,7 +43,7 @@ const (
 	TracepointInetSockSetState = "sock/inet_sock_set_state"
 )
 
-// program names
+// Program names
 const (
 	progObiKprobeTcpCloseSrtt         = "obi_kprobe_tcp_close_srtt"
 	progObiTracepointInetSockSetState = "obi_tracepoint_inet_sock_set_state"
@@ -82,12 +82,9 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 
 	objects := &StatsObjects{}
 
-	// Probe metadata, grouped by attach type. Each slice drives both spec
-	// deletion (so disabled probes never enter the kernel) and the per-type
-	// attach loop below.
-	//
-	// Do not use LoadSpec from the convenience pkg because we need
-	// NewCollectionWithOptions instead of LoadAndAssign for this use case.
+	// Probe metadata, grouped by attach type. Each slice drives both the
+	// enabled-program list passed to LoadPartial and the per-type attach
+	// loop below.
 	kprobes := []probe{
 		{
 			progName: progObiKprobeTcpCloseSrtt,
@@ -105,28 +102,19 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 		},
 	}
 
-	// Drop programs the user disabled so NewCollectionWithOptions won't load them.
-	dropDisabledPrograms(spec, kprobes, tracepoints)
-
-	if err := ebpfconvenience.RewriteConstants(spec, map[string]any{
-		"g_bpf_debug": cfg.BpfDebug,
-	}); err != nil {
-		return nil, fmt.Errorf("rewriting BPF constants: %w", err)
-	}
-
 	ebpfconvenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor)
 
-	// statsolly intentionally doesn't share maps with other specs
+	// statsolly intentionally doesn't share maps with other specs.
 	sharedMaps := map[string]*ebpf.Map{}
 	var mu sync.Mutex
-	collOpts, err := ebpfconvenience.ResolveMaps(spec, sharedMaps, &mu)
-	if err != nil {
-		return nil, fmt.Errorf("resolving maps: %w", err)
-	}
-	collOpts.Programs = ebpf.ProgramOptions{LogSizeStart: 640 * 1024}
-	// collOpts.Maps.PinPath stays zero; statsolly passes "" today.
-
-	coll, err := ebpf.NewCollectionWithOptions(spec, *collOpts)
+	coll, err := ebpfconvenience.LoadPartial(
+		spec,
+		enabledProgramNames(kprobes, tracepoints),
+		map[string]any{"g_bpf_debug": cfg.BpfDebug},
+		sharedMaps,
+		&mu,
+		"",
+	)
 	if err != nil {
 		return nil, fmt.Errorf("loading stats eBPF collection: %w", err)
 	}
@@ -135,10 +123,12 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 
 	objects.StatsEvents = coll.DetachMap(mapStatsEvents)
 	if objects.StatsEvents == nil {
+		objects.Close()
 		return nil, fmt.Errorf("map %q not found in collection", mapStatsEvents)
 	}
 	objects.DebugEvents = coll.DetachMap(mapDebugEvents)
 	if objects.DebugEvents == nil {
+		objects.Close()
 		return nil, fmt.Errorf("map %q not found in collection", mapDebugEvents)
 	}
 
@@ -196,16 +186,19 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 	}, nil
 }
 
-// dropDisabledPrograms removes from spec.Programs any probe whose enabled flag
-// is false, so NewCollectionWithOptions does not load it into the kernel.
-func dropDisabledPrograms(spec *ebpf.CollectionSpec, probeGroups ...[]probe) {
+// enabledProgramNames returns the program names of all enabled probes across
+// the given groups. Used to tell LoadPartial which programs should reach the
+// kernel; disabled probes are stripped from the spec before load.
+func enabledProgramNames(probeGroups ...[]probe) []string {
+	var names []string
 	for _, group := range probeGroups {
 		for _, p := range group {
-			if !p.enabled {
-				delete(spec.Programs, p.progName)
+			if p.enabled {
+				names = append(names, p.progName)
 			}
 		}
 	}
+	return names
 }
 
 func closeAll(closables []io.Closer) {
@@ -216,7 +209,6 @@ func closeAll(closables []io.Closer) {
 	}
 }
 
-// Close any resources that are taken
 func (m *StatsFetcher) Close() error {
 	m.log.Debug("unregistering eBPF objects")
 

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/rlimit"
 
@@ -68,8 +69,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 		return nil, fmt.Errorf("loading BPF data: %w", err)
 	}
 
-	// pino test, delete one fixes probe
-	delete(spec.Programs, "obi_tracepoint_inet_sock_set_state") // drop failed-conn
+	fixupSpec(spec, features)
 
 	ebpfconvenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor)
 
@@ -164,4 +164,29 @@ func (m *StatsFetcher) StatsEventsMap() *ebpf.Map {
 
 func (m *StatsFetcher) DebugEventsMap() *ebpf.Map {
 	return m.objects.DebugEvents
+}
+
+func fixupSpec(spec *ebpf.CollectionSpec, features *export.Features) {
+	if !features.StatsTCPFailedConnections() {
+		spec.Programs["obi_tracepoint_inet_sock_set_state"] = &ebpf.ProgramSpec{
+			Name: "obi_dummy_statsolly_tp",
+			Type: ebpf.TracePoint,
+			Instructions: asm.Instructions{
+				asm.Mov.Imm(asm.R0, 0),
+				asm.Return(),
+			},
+			License: "Dual MIT/GPL",
+		}
+	}
+	if !features.StatsTCPRtt() {
+		spec.Programs["obi_kprobe_tcp_close_srtt"] = &ebpf.ProgramSpec{
+			Name: "obi_dummy_statsolly_kp",
+			Type: ebpf.Kprobe,
+			Instructions: asm.Instructions{
+				asm.Mov.Imm(asm.R0, 0),
+				asm.Return(),
+			},
+			License: "Dual MIT/GPL",
+		}
+	}
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -166,11 +166,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 		}
 		t.out(prog)
 
-		group, tp, ok := strings.Cut(t.hookName, "/")
-		if !ok {
-			closeAll(closables)
-			return nil, fmt.Errorf("invalid tracepoint %q: must be group/name", t.hookName)
-		}
+		group, tp, _ := strings.Cut(t.hookName, "/")
 		l, err := link.Tracepoint(group, tp, prog, nil)
 		if err != nil {
 			closeAll(closables)

--- a/pkg/internal/statsolly/ebpf/stats_tracer_test.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_test.go
@@ -1,0 +1,92 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+func TestDropDisabledPrograms(t *testing.T) {
+	makeSpec := func() *ebpf.CollectionSpec {
+		return &ebpf.CollectionSpec{
+			Programs: map[string]*ebpf.ProgramSpec{
+				progObiKprobeTcpCloseSrtt:         {Name: progObiKprobeTcpCloseSrtt},
+				progObiTracepointInetSockSetState: {Name: progObiTracepointInetSockSetState},
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		rttEnabled   bool
+		failedEnabled bool
+		want         map[string]bool // progName -> should remain in spec
+	}{
+		{
+			name:          "both enabled",
+			rttEnabled:    true,
+			failedEnabled: true,
+			want: map[string]bool{
+				progObiKprobeTcpCloseSrtt:         true,
+				progObiTracepointInetSockSetState: true,
+			},
+		},
+		{
+			name:          "rtt only",
+			rttEnabled:    true,
+			failedEnabled: false,
+			want: map[string]bool{
+				progObiKprobeTcpCloseSrtt:         true,
+				progObiTracepointInetSockSetState: false,
+			},
+		},
+		{
+			name:          "failed-conn only",
+			rttEnabled:    false,
+			failedEnabled: true,
+			want: map[string]bool{
+				progObiKprobeTcpCloseSrtt:         false,
+				progObiTracepointInetSockSetState: true,
+			},
+		},
+		{
+			name:          "both disabled",
+			rttEnabled:    false,
+			failedEnabled: false,
+			want: map[string]bool{
+				progObiKprobeTcpCloseSrtt:         false,
+				progObiTracepointInetSockSetState: false,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := makeSpec()
+			kprobes := []probe{{
+				progName: progObiKprobeTcpCloseSrtt,
+				hookName: KprobeTCPClose,
+				enabled:  tc.rttEnabled,
+			}}
+			tracepoints := []probe{{
+				progName: progObiTracepointInetSockSetState,
+				hookName: TracepointInetSockSetState,
+				enabled:  tc.failedEnabled,
+			}}
+
+			dropDisabledPrograms(spec, kprobes, tracepoints)
+
+			for name, shouldRemain := range tc.want {
+				_, present := spec.Programs[name]
+				if present != shouldRemain {
+					t.Errorf("program %q: present=%v, want %v", name, present, shouldRemain)
+				}
+			}
+		})
+	}
+}

--- a/pkg/internal/statsolly/ebpf/stats_tracer_test.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_test.go
@@ -7,8 +7,20 @@ package ebpf
 
 import (
 	"sort"
+	"strings"
 	"testing"
 )
+
+func TestTracepointConstantFormat(t *testing.T) {
+	hooks := []string{
+		TracepointInetSockSetState,
+	}
+	for _, hook := range hooks {
+		if _, _, ok := strings.Cut(hook, "/"); !ok {
+			t.Errorf("tracepoint constant %q is not in group/name format", hook)
+		}
+	}
+}
 
 func TestEnabledProgramNames(t *testing.T) {
 	tests := []struct {

--- a/pkg/internal/statsolly/ebpf/stats_tracer_test.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_test.go
@@ -6,68 +6,48 @@
 package ebpf
 
 import (
+	"sort"
 	"testing"
-
-	"github.com/cilium/ebpf"
 )
 
-func TestDropDisabledPrograms(t *testing.T) {
-	makeSpec := func() *ebpf.CollectionSpec {
-		return &ebpf.CollectionSpec{
-			Programs: map[string]*ebpf.ProgramSpec{
-				progObiKprobeTcpCloseSrtt:         {Name: progObiKprobeTcpCloseSrtt},
-				progObiTracepointInetSockSetState: {Name: progObiTracepointInetSockSetState},
-			},
-		}
-	}
-
+func TestEnabledProgramNames(t *testing.T) {
 	tests := []struct {
-		name         string
-		rttEnabled   bool
+		name          string
+		rttEnabled    bool
 		failedEnabled bool
-		want         map[string]bool // progName -> should remain in spec
+		want          []string
 	}{
 		{
 			name:          "both enabled",
 			rttEnabled:    true,
 			failedEnabled: true,
-			want: map[string]bool{
-				progObiKprobeTcpCloseSrtt:         true,
-				progObiTracepointInetSockSetState: true,
+			want: []string{
+				progObiKprobeTcpCloseSrtt,
+				progObiTracepointInetSockSetState,
 			},
 		},
 		{
 			name:          "rtt only",
 			rttEnabled:    true,
 			failedEnabled: false,
-			want: map[string]bool{
-				progObiKprobeTcpCloseSrtt:         true,
-				progObiTracepointInetSockSetState: false,
-			},
+			want:          []string{progObiKprobeTcpCloseSrtt},
 		},
 		{
 			name:          "failed-conn only",
 			rttEnabled:    false,
 			failedEnabled: true,
-			want: map[string]bool{
-				progObiKprobeTcpCloseSrtt:         false,
-				progObiTracepointInetSockSetState: true,
-			},
+			want:          []string{progObiTracepointInetSockSetState},
 		},
 		{
 			name:          "both disabled",
 			rttEnabled:    false,
 			failedEnabled: false,
-			want: map[string]bool{
-				progObiKprobeTcpCloseSrtt:         false,
-				progObiTracepointInetSockSetState: false,
-			},
+			want:          nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			spec := makeSpec()
 			kprobes := []probe{{
 				progName: progObiKprobeTcpCloseSrtt,
 				hookName: KprobeTCPClose,
@@ -79,12 +59,17 @@ func TestDropDisabledPrograms(t *testing.T) {
 				enabled:  tc.failedEnabled,
 			}}
 
-			dropDisabledPrograms(spec, kprobes, tracepoints)
+			got := enabledProgramNames(kprobes, tracepoints)
+			sort.Strings(got)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
 
-			for name, shouldRemain := range tc.want {
-				_, present := spec.Programs[name]
-				if present != shouldRemain {
-					t.Errorf("program %q: present=%v, want %v", name, present, shouldRemain)
+			if len(got) != len(want) {
+				t.Fatalf("got %v, want %v", got, want)
+			}
+			for i := range got {
+				if got[i] != want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], want[i])
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

This PR allows statsolly to load into the kernel only the probes needed to calculate the metrics requested by the user during configuration. Currently, all probes were loaded and only the necessary ones were attached.

To achieve this, the `LoadPartial` function was introduced, which calls the `NewCollectionWithOptions` function instead of the `LoadAndAssign` function.

Aside from this, unit tests were introduced and the runtime check for the loop point name for tracepoints was removed by adding a dedicated unit test.

Note on `probe.out`: The `out func(*ebpf.Program)` field on `probe` looks like unnecessary indirection
but is needed. The bpf2go-generated `StatsPrograms.Close()` calls `.Close()` on every program field directly, so a nil `*ebpf.Program` wrapped as `io.Closer` would panic. `out` populates the typed struct fields for programs that were actually loaded, ensuring `objects.Close()` is always safe to call.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
