### PR TITLE
ci: notify coralogix/documentation on OBI release

### DIFF
--- a/.github/workflows/notify-docs-on-version-bump.yml
+++ b/.github/workflows/notify-docs-on-version-bump.yml
@@ -1,0 +1,41 @@
+name: Notify docs on version bump
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    # Skip pre-releases and drafts — docs track stable releases only.
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve previous stable release
+        id: prev
+        run: |
+          PREV=$(curl -s \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/releases" \
+            | jq -r --arg new "${{ github.event.release.tag_name }}" \
+              '[.[] | select(.prerelease == false and .draft == false) | .tag_name]
+               | map(select(. != $new)) | .[0] // ""')
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger docs version bump
+        run: |
+          curl -X POST \
+               -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               https://api.github.com/repos/coralogix/documentation/dispatches \
+               -d "{
+                 \"event_type\": \"component-version-bump\",
+                 \"client_payload\": {
+                   \"component\": \"obi\",
+                   \"new_version\": \"${{ github.event.release.tag_name }}\",
+                   \"old_version\": \"${{ steps.prev.outputs.prev }}\"
+                 }
+               }"


### PR DESCRIPTION
## Summary

Adds a workflow that fires a \`component-version-bump\` \`repository_dispatch\` on \`coralogix/documentation\` whenever a stable OBI release is published.

The docs portal receiver ([handle-chart-bump.yml](https://github.com/coralogix/documentation/blob/master/.github/workflows/handle-chart-bump.yml)) opens a draft PR to rotate snippet folders and update the version registry for the \`obi\` component.

## How it works

1. Triggers on \`release: published\` (skips pre-releases and drafts)
2. Resolves the previous stable release tag from the GitHub API
3. Dispatches \`{component: "obi", new_version, old_version}\` to \`coralogix/documentation\`

Also exposed as \`workflow_dispatch\` for manual triggering from the Actions tab.

## Prereqs

- \`secrets.GH_TOKEN\` must have \`repo\` scope on \`coralogix/documentation\` to dispatch events. Please confirm with infra before merging.

## Test plan
- [ ] After merge, trigger via **Run workflow** from the Actions tab and verify the dispatch reaches \`coralogix/documentation\` and \`handle-chart-bump.yml\` fires.
- [ ] On the next real release, confirm a draft PR is opened in \`coralogix/documentation\` with the correct \`obi\` version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)