### PR TITLE
logenricher: support multi-segment iovec writes, stamp '\n' over last byte of suppressed write

### DIFF
--- a/bpf/logenricher/logenricher.c
+++ b/bpf/logenricher/logenricher.c
@@ -47,46 +47,102 @@ static __always_inline bool pid_tracked(const struct task_struct *task) {
     return tracked != NULL;
 }
 
-static __always_inline bool __fill_iov(struct iovec *iov, struct iov_iter *from) {
-    iovec_iter_ctx iov_ctx;
-    get_iovec_ctx(&iov_ctx, (struct iov_iter___dummy *)from);
+static __always_inline u32 consume_ubuf(log_event_t *e,
+                                        struct iov_iter *from,
+                                        void *ubuf,
+                                        const char *fill) {
+    const size_t count = BPF_CORE_READ(from, count);
+    u32 to_copy = (u32)count;
 
-    if (bpf_core_enum_value_exists(enum iter_type___dummy, ITER_UBUF) &&
-        iov_ctx.iter_type == bpf_core_enum_value(enum iter_type___dummy, ITER_UBUF)) {
-        const long offset = bpf_core_field_offset(struct iov_iter, count) - 8;
-        bpf_probe_read(iov, sizeof(*iov), (char *)from + offset);
-    } else if (iov_ctx.iter_type == bpf_core_enum_value(enum iter_type, ITER_IOVEC) &&
-               iov_ctx.iov) {
-        bpf_probe_read(iov, sizeof(*iov), &iov_ctx.iov[0]);
-    } else {
-        bpf_dbg_printk("logenricher: unsupported iter_type %d", iov_ctx.iter_type);
-        return false;
+    bpf_clamp_umax(to_copy, k_log_event_max_log_len);
+    if (to_copy == 0) {
+        return 0;
     }
 
-    return iov->iov_base && iov->iov_len;
+    bpf_probe_read_user(e->log, to_copy, ubuf);
+    bpf_clamp_umin(to_copy, 1);
+    bpf_probe_write_user(ubuf, fill, to_copy);
+    bpf_probe_write_user((char *)ubuf + to_copy - 1, &k_newline, 1);
+
+    return to_copy;
+}
+
+static __always_inline u32 consume_iovec(log_event_t *e,
+                                         const struct iovec *iov,
+                                         unsigned long nr_segs,
+                                         const char *fill) {
+    u32 tot = 0;
+    void *last_end = NULL;
+
+    bpf_clamp_umax(nr_segs, k_iov_max_segs);
+
+    for (unsigned long i = 0; i < k_iov_max_segs && i < nr_segs; i++) {
+        struct iovec vec;
+        if (bpf_probe_read_kernel(&vec, sizeof(vec), &iov[i]) != 0) {
+            break;
+        }
+        if (!vec.iov_base || !vec.iov_len) {
+            continue;
+        }
+
+        u32 to_copy = (u32)vec.iov_len;
+        bpf_clamp_umax(to_copy, k_iov_seg_max_len);
+        bpf_clamp_umax(tot, k_log_event_max_log_len);
+        if (tot + to_copy > k_log_event_max_log_len) {
+            break;
+        }
+
+        bpf_probe_read_user(&e->log[tot], to_copy, vec.iov_base);
+        bpf_clamp_umin(to_copy, 1);
+        bpf_probe_write_user(vec.iov_base, fill, to_copy);
+        last_end = (char *)vec.iov_base + to_copy - 1;
+        tot += to_copy;
+    }
+
+    if (last_end) {
+        bpf_probe_write_user(last_end, &k_newline, 1);
+    }
+    return tot;
 }
 
 static __always_inline int
 __write(struct kiocb *iocb, struct iov_iter *from, const int fd, const struct task_struct *task) {
-    struct iovec iov = {};
-    if (!__fill_iov(&iov, from)) {
-        return 0;
-    }
-
-    const size_t count = BPF_CORE_READ(from, count);
-    const u64 pid_tgid = bpf_get_current_pid_tgid();
-    obi_ctx_info_t *obi_ctx = obi_ctx__get(pid_tgid);
+    iovec_iter_ctx ictx;
+    get_iovec_ctx(&ictx, (struct iov_iter___dummy *)from);
 
     log_event_t *e = (log_event_t *)log_event_mem();
     if (!e) {
         bpf_dbg_printk("logenricher: failed to reserve event space");
         return 0;
     }
+    char *fill = bpf_map_lookup_elem(&zeros, &(u32){0});
+    if (!fill) {
+        bpf_dbg_printk("logenricher: failed to get zero buffer");
+        return 0;
+    }
+
+    const u64 pid_tgid = bpf_get_current_pid_tgid();
+    obi_ctx_info_t *obi_ctx = obi_ctx__get(pid_tgid);
     e->tgid = pid_tgid >> 32;
-    e->len = count & k_log_event_max_log_mask;
     e->ctx = obi_ctx ? *obi_ctx : (obi_ctx_info_t){0};
     e->fd = fd;
-    bpf_probe_read_user(e->log, e->len, iov.iov_base);
+
+    u32 tot = 0;
+
+    if (bpf_core_enum_value_exists(enum iter_type___dummy, ITER_UBUF) &&
+        ictx.iter_type == bpf_core_enum_value(enum iter_type___dummy, ITER_UBUF) && ictx.ubuf) {
+        tot = consume_ubuf(e, from, ictx.ubuf, fill);
+    } else if (ictx.iter_type == bpf_core_enum_value(enum iter_type, ITER_IOVEC) && ictx.iov) {
+        tot = consume_iovec(e, ictx.iov, ictx.nr_segs, fill);
+    } else {
+        bpf_dbg_printk("logenricher: unsupported iter_type %d", ictx.iter_type);
+        return 0;
+    }
+
+    e->len = tot;
+    if (e->len == 0) {
+        return 0;
+    }
 
     if (fd == 0) {
         // We are in the TTY path so we can resolve the filepath
@@ -101,32 +157,11 @@ __write(struct kiocb *iocb, struct iov_iter *from, const int fd, const struct ta
         e->file_path[0] = '\0';
     }
 
-    if (e->len > 0) {
-        // From this point on, the responsibility of writing to stdout is on us,
-        // so if something fails, we must always fallback to writing the original data.
-        const long err =
-            bpf_ringbuf_output(&log_events,
-                               e,
-                               (sizeof(log_event_t) + e->len) & k_log_event_max_size_mask,
-                               log_events_flags());
-        if (err < 0) {
-            bpf_dbg_printk("logenricher: failed to write log event to ringbuf: %d", err);
-            return 0;
-        }
-
-        // Delete current buffer to avoid double logging.
-        char *zero = bpf_map_lookup_elem(&zeros, &(u32){0});
-        if (!zero) {
-            bpf_dbg_printk("logenricher: failed to get zero buffer");
-            return 0;
-        }
-
-        u32 to_write = e->len & k_log_event_max_log_mask;
-        if (to_write == 0) {
-            return 0;
-        }
-        bpf_clamp_umin(to_write, 1);
-        bpf_probe_write_user(iov.iov_base, zero, to_write);
+    u64 out_size = sizeof(log_event_t) + e->len;
+    bpf_clamp_umax(out_size, k_log_event_max_size - 1);
+    const long err = bpf_ringbuf_output(&log_events, e, out_size, log_events_flags());
+    if (err < 0) {
+        bpf_dbg_printk("logenricher: failed to write log event to ringbuf: %d", err);
     }
 
     return 0;

--- a/bpf/logenricher/maps/zeros.h
+++ b/bpf/logenricher/maps/zeros.h
@@ -13,7 +13,7 @@
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __type(key, u32);
-    __type(value, char[k_log_event_max_size]);
+    __type(value, char[k_log_event_max_log_len]);
     __uint(max_entries, 1);
     __uint(pinning, OBI_PIN_INTERNAL);
 } zeros SEC(".maps");

--- a/bpf/logenricher/types.h
+++ b/bpf/logenricher/types.h
@@ -18,14 +18,19 @@ enum {
     k_echo = 0x00008,
 
     // log handling
-    k_log_event_max_size = 1 << 14,                       // 16K
-    k_log_event_max_size_mask = k_log_event_max_size - 1, // 16K - 1
-    k_log_event_max_log_mask = (1 << 13) - 1,             // 8K - 1
+    k_log_event_max_size = 1 << 14,    // 16K
+    k_log_event_max_log_len = 1 << 13, // 8K
+
+    // iovec
+    k_iov_max_segs = 8,
+    k_iov_seg_max_len = 8000,
 
     // terminal file
     k_pts_file_path_len_max = 64,
     k_pts_file_path_len_max_mask = k_pts_file_path_len_max - 1,
 };
+
+static const char k_newline = '\n';
 
 typedef struct log_event {
     u32 tgid;

--- a/devdocs/trace-log-correlation.md
+++ b/devdocs/trace-log-correlation.md
@@ -15,7 +15,9 @@ OBI can enrich JSON log lines with `trace_id` and `span_id` fields, linking logs
   - [Python (asyncio) — `task_step` / `context_run` uprobes](#python-asyncio--task_step--context_run-uprobes)
 - [Per-runtime stdout buffering](#per-runtime-stdout-buffering)
   - [.NET specifics](#net-specifics)
+- [Filtering the suppressed placeholder lines](#filtering-the-suppressed-placeholder-lines)
 - [Requirements](#requirements)
+- [Limits](#limits)
 
 ## Overview
 
@@ -26,7 +28,7 @@ The logenricher hooks into write paths (`tty_write`, `pipe_write`, `ksys_write`,
 3. Overwrites the original user buffer with zeros via `bpf_probe_write_user` to suppress the un-enriched line.
 4. User-space reads from the ring buffer and re-emits the log with `trace_id`/`span_id` injected into the JSON.
 
-Because the original user buffer is zeroed out (step 3), the container log file will contain NULL characters in place of the original log line. This is expected — the enriched line is written separately by user-space, and the NULLs prevent the container runtime from capturing the un-enriched duplicate.
+Because the original user buffer is zeroed out (step 3), the container log file will contain NULL characters in place of the original log line, terminated with `\n` so each suppressed write becomes one placeholder line that downstream tooling can drop with a single regex (see [Filtering the suppressed placeholder lines](#filtering-the-suppressed-placeholder-lines)). The enriched line is written separately by user-space, and the NULL suppression prevents the container runtime from capturing the un-enriched duplicate.
 
 Both `ITER_UBUF` (kernel ≥ 6.0, used by `write()`) and `ITER_IOVEC` (all kernel versions, used by `writev()`) iterator types are supported. The `do_writev` kprobe captures the fd for `writev()` calls so `pipe_write` can resolve the file descriptor (registered as non-required — if the symbol isn't available, `write()`-based enrichment still works).
 
@@ -151,9 +153,71 @@ Console.SetOut(stdout);
 
 There is no environment variable equivalent to Python's `PYTHONUNBUFFERED=1` for .NET.
 
+## Filtering the suppressed placeholder lines
+
+Each traced `write()`/`writev()` leaves one placeholder line in the
+container log: the original bytes are overwritten with NULs and a
+trailing `\n`. Drop them downstream with the regex `^[\x00\s]*$`. See
+[Limits](#limits) for the per-write size cap.
+
+JSON log envelopes (CRI body, Docker `log` field) serialise NUL as
+`\u0000`; both shippers below decode the JSON string before the filter
+runs, so the regex matches real `\x00` bytes.
+
+### OpenTelemetry Collector — `filelog` receiver
+
+The `container` operator handles CRI and Docker JSON formats and
+exposes the line in `body`.
+
+```yaml
+receivers:
+  filelog:
+    include:
+      - /var/log/pods/*/*/*.log
+    start_at: end
+    operators:
+      - type: container
+      - type: filter
+        expr: 'body matches "^[\\x00\\s]*$"'
+```
+
+### Fluent Bit
+
+```ini
+[INPUT]
+    Name              tail
+    Path              /var/log/pods/*/*/*.log
+    multiline.parser  cri
+    Tag               kube.*
+
+[FILTER]
+    Name    grep
+    Match   *
+    Exclude log ^[\x00\s]*$
+```
+
+### Legacy: Docker JSON log driver
+
+```yaml
+receivers:
+  filelog:
+    include: [/var/lib/docker/containers/*/*-json.log]
+    operators:
+      - type: json_parser
+        parse_from: body
+        parse_to: attributes
+      - type: filter
+        # bracket access: `log` collides with expr-lang math.log
+        expr: 'attributes["log"] matches "^[\\x00\\s]*$"'
+```
+
 ## Requirements
 
 - `CAP_SYS_ADMIN` capability and permission to use `bpf_probe_write_user` (kernel security lockdown mode should be `[none]`)
 - The target application writes logs in **JSON format**
 - Log writes must occur synchronously on the request-handling thread (see [Per-runtime stdout buffering](#per-runtime-stdout-buffering) above)
 - BPFFS mounted at `/sys/fs/bpf` (or another mountpath configurable via `config.ebpf.bpf_fs_path` / `OTEL_EBPF_BPF_FS_PATH`)
+
+## Limits
+
+- **Per-write cap of 8 KiB.** Bytes past 8 KiB in a single `write()`/`writev()` are not zeroed or enriched; they leak through the tty/pipe as-is.

--- a/internal/test/integration/components/logenricher_writev/Dockerfile
+++ b/internal/test/integration/components/logenricher_writev/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+FROM gcc:14.3.0-trixie@sha256:15923fde7cc441594a4daad0e4b33027c8a53174ffd1b6e38d36789db5ef50d4 AS builder
+
+WORKDIR /src
+COPY internal/test/integration/components/logenricher_writev/multiseg_writev.c .
+RUN gcc -O2 -static -o multiseg_writev multiseg_writev.c
+
+FROM debian:bookworm-slim@sha256:74d56e3931e0d5a1dd51f8c8a2466d21de84a271cd3b5a733b803aa91abf4421
+
+COPY --from=builder /src/multiseg_writev /multiseg_writev
+EXPOSE 8388
+ENTRYPOINT ["/multiseg_writev"]

--- a/internal/test/integration/components/logenricher_writev/multiseg_writev.c
+++ b/internal/test/integration/components/logenricher_writev/multiseg_writev.c
@@ -1,0 +1,196 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Tiny HTTP server that exercises the logenricher multi-segment iovec path.
+// On GET /json_logger it parses the W3C `traceparent` header and emits a JSON
+// log line via writev(2) with 3 separate iovec segments. The kernel presents
+// this as a single ITER_IOVEC iov_iter to pipe_write, so the BPF logenricher
+// must concatenate all segments to reconstruct the line.
+//
+// On GET /smoke it returns 200 — used by the test harness for readiness.
+//
+// Build: gcc -O2 -static -o multiseg_writev multiseg_writev.c
+// Run:   PORT=8388 ./multiseg_writev
+
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <ctype.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#define LISTEN_PORT_DEFAULT 8388
+#define BUF_SIZE 8192
+
+static const char http_200_ok[] =
+    "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+static const char http_404[] =
+    "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
+
+static int extract_trace_id(const char *tp, char out[33]) {
+  if (!tp)
+    return 0;
+  const char *dash = strchr(tp, '-');
+  if (!dash)
+    return 0;
+  const char *trace_start = dash + 1;
+  const char *trace_end = strchr(trace_start, '-');
+  if (!trace_end)
+    return 0;
+  size_t n = (size_t)(trace_end - trace_start);
+  if (n != 32)
+    return 0;
+  memcpy(out, trace_start, 32);
+  out[32] = '\0';
+  return 1;
+}
+
+static void parse_request_line(const char *buf, char path[64]) {
+  path[0] = '\0';
+  while (*buf && *buf != ' ')
+    buf++;
+  while (*buf == ' ')
+    buf++;
+  size_t pi = 0;
+  while (*buf && *buf != ' ' && *buf != '\r' && *buf != '?' && pi < 63) {
+    path[pi++] = *buf++;
+  }
+  path[pi] = '\0';
+}
+
+static const char *find_header(const char *buf, const char *name,
+                               size_t *out_len) {
+  size_t nlen = strlen(name);
+  const char *p = buf;
+  while ((p = strstr(p, "\r\n")) != NULL) {
+    p += 2;
+    if (*p == '\r' || *p == '\0')
+      break;
+    int matched = 1;
+    for (size_t i = 0; i < nlen; i++) {
+      if (tolower((unsigned char)p[i]) != tolower((unsigned char)name[i])) {
+        matched = 0;
+        break;
+      }
+    }
+    if (matched && p[nlen] == ':') {
+      const char *v = p + nlen + 1;
+      while (*v == ' ' || *v == '\t')
+        v++;
+      const char *end = strstr(v, "\r\n");
+      if (!end)
+        return NULL;
+      *out_len = (size_t)(end - v);
+      return v;
+    }
+  }
+  return NULL;
+}
+
+// Split JSON across 3 iovec segments so the kernel iov_iter has nr_segs==3.
+// The BPF logenricher must concatenate all segments to capture the full line.
+static void emit_multiseg_log(const char *trace_id_or_empty) {
+  static const char seg1[] =
+      "{\"level\":\"INFO\",\"message\":\"this is a json log via multi-seg "
+      "writev\",\"traceparent_seen\":\"";
+  static const char seg3[] = "\"}\n";
+
+  struct iovec iov[3];
+  iov[0].iov_base = (void *)seg1;
+  iov[0].iov_len = sizeof(seg1) - 1;
+  iov[1].iov_base = (void *)trace_id_or_empty;
+  iov[1].iov_len = strlen(trace_id_or_empty);
+  iov[2].iov_base = (void *)seg3;
+  iov[2].iov_len = sizeof(seg3) - 1;
+
+  if (writev(STDOUT_FILENO, iov, 3) < 0) {
+    perror("writev");
+  }
+}
+
+static void handle_client(int fd) {
+  char buf[BUF_SIZE];
+  ssize_t total = 0;
+  while (total < (ssize_t)sizeof(buf) - 1) {
+    ssize_t r = recv(fd, buf + total, sizeof(buf) - 1 - total, 0);
+    if (r <= 0) {
+      close(fd);
+      return;
+    }
+    total += r;
+    buf[total] = '\0';
+    if (strstr(buf, "\r\n\r\n"))
+      break;
+  }
+
+  char path[64];
+  parse_request_line(buf, path);
+
+  if (strcmp(path, "/smoke") == 0 || strcmp(path, "/json_logger") == 0) {
+    if (strcmp(path, "/json_logger") == 0) {
+      char trace_id[33] = "";
+      size_t tp_len = 0;
+      const char *tp = find_header(buf, "traceparent", &tp_len);
+      if (tp && tp_len < 200) {
+        char tp_buf[256];
+        memcpy(tp_buf, tp, tp_len);
+        tp_buf[tp_len] = '\0';
+        extract_trace_id(tp_buf, trace_id);
+      }
+      emit_multiseg_log(trace_id);
+    }
+    send(fd, http_200_ok, sizeof(http_200_ok) - 1, 0);
+    close(fd);
+    return;
+  }
+
+  send(fd, http_404, sizeof(http_404) - 1, 0);
+  close(fd);
+}
+
+int main(void) {
+  int port = LISTEN_PORT_DEFAULT;
+  const char *port_env = getenv("PORT");
+  if (port_env)
+    port = atoi(port_env);
+
+  int srv = socket(AF_INET, SOCK_STREAM, 0);
+  if (srv < 0) {
+    perror("socket");
+    return 1;
+  }
+  int one = 1;
+  setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+  struct sockaddr_in addr = {
+      .sin_family = AF_INET,
+      .sin_port = htons(port),
+      .sin_addr.s_addr = htonl(INADDR_ANY),
+  };
+  if (bind(srv, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    perror("bind");
+    return 1;
+  }
+  if (listen(srv, 64) < 0) {
+    perror("listen");
+    return 1;
+  }
+  fprintf(stderr, "multiseg_writev listening on :%d\n", port);
+  fflush(stderr);
+
+  for (;;) {
+    int c = accept(srv, NULL, NULL);
+    if (c < 0) {
+      if (errno == EINTR)
+        continue;
+      perror("accept");
+      continue;
+    }
+    handle_client(c);
+  }
+}

--- a/internal/test/integration/configs/fluentbit-multiseg-filter.conf
+++ b/internal/test/integration/configs/fluentbit-multiseg-filter.conf
@@ -1,0 +1,27 @@
+# Validates the fluent-bit filter config documented in
+# devdocs/trace-log-correlation.md drops the NUL-stuffed lines that the BPF
+# logenricher leaves on stdout while keeping the OBI-enriched JSON lines.
+[SERVICE]
+    Flush        1
+    Daemon       Off
+    Log_Level    warn
+    Parsers_File parsers.conf
+
+[INPUT]
+    Name             tail
+    Path             /var/lib/docker/containers/*/*-json.log
+    Parser           docker
+    Tag              docker.*
+    Read_from_Head   true
+
+[FILTER]
+    Name    grep
+    Match   *
+    Exclude log ^[\x00\s]*$
+
+[OUTPUT]
+    Name  file
+    Match *
+    Path  /output
+    File  fluentbit-filtered.json
+    Format plain

--- a/internal/test/integration/configs/obi-config-log-enricher.yml
+++ b/internal/test/integration/configs/obi-config-log-enricher.yml
@@ -16,7 +16,7 @@ ebpf:
   log_enricher:
     services:
       - service:
-        - open_ports: "8380,50051,3030,8085,3040"
+        - open_ports: "8380,50051,3030,8085,3040,8388"
 discovery:
   min_process_age: "0s"
 log_config: "yaml"

--- a/internal/test/integration/configs/otelcol-multiseg-filter.yaml
+++ b/internal/test/integration/configs/otelcol-multiseg-filter.yaml
@@ -1,0 +1,30 @@
+# Validates the otel collector filter config documented in
+# devdocs/trace-log-correlation.md drops the NUL-stuffed lines that the BPF
+# logenricher leaves on stdout while keeping the OBI-enriched JSON lines.
+receivers:
+  filelog:
+    include:
+      - /var/lib/docker/containers/*/*-json.log
+    start_at: beginning
+    operators:
+      - type: json_parser
+        parse_from: body
+        parse_to: attributes
+      - type: filter
+        expr: 'attributes["log"] matches "^[\\x00\\s]*$"'
+
+exporters:
+  file:
+    path: /output/otelcol-filtered.json
+    # Flush every 100ms so late-arriving OBI-enriched lines surface in
+    # the test's polling window (default flush is ~1s)
+    flush_interval: 100ms
+
+service:
+  telemetry:
+    logs:
+      level: warn
+  pipelines:
+    logs:
+      receivers: [filelog]
+      exporters: [file]

--- a/internal/test/integration/docker-compose-log-enricher.yml
+++ b/internal/test/integration/docker-compose-log-enricher.yml
@@ -78,6 +78,45 @@ services:
       UVICORN_LOOP: "uvloop"
       BACKEND_URL: "http://testserverhttp:8380"
 
+  testservermultisegwritev:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/logenricher_writev/Dockerfile
+    image: hatest-testserver-logenricher-multiseg-writev
+    networks:
+      - shared
+    ports:
+      - "8388:8388"
+    environment:
+      PORT: "8388"
+
+  multisegwritev_otelcol:
+    image: otel/opentelemetry-collector-contrib:0.151.0@sha256:d57bfe8eee2378f31cb1193239fbcac521d54a5a071fca2bfc106916a32b892d
+    user: "0:0"
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - ./configs/otelcol-multiseg-filter.yaml:/etc/otelcol-contrib/config.yaml:ro
+      - ../../../testoutput/multiseg-shipper-output:/output
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    networks:
+      - shared
+    depends_on:
+      testservermultisegwritev:
+        condition: service_started
+
+  multisegwritev_fluentbit:
+    image: fluent/fluent-bit:3.1.10@sha256:e72c08d2ec8d93999dfb74b17bd0ec8bcb07fedde0d53308f59e7aa0b5f293e1
+    user: "0:0"
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - ./configs/fluentbit-multiseg-filter.conf:/fluent-bit/etc/fluent-bit.conf:ro
+      - ../../../testoutput/multiseg-shipper-output:/output
+    networks:
+      - shared
+    depends_on:
+      testservermultisegwritev:
+        condition: service_started
+
   obi:
     build:
       context: ../../..
@@ -126,6 +165,8 @@ services:
       testserverdotnet:
         condition: service_started
       testserverpythonasync:
+        condition: service_started
+      testservermultisegwritev:
         condition: service_started
 
 networks:

--- a/internal/test/integration/log_enricher_test.go
+++ b/internal/test/integration/log_enricher_test.go
@@ -9,6 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -87,6 +90,13 @@ var (
 		containerImage: "hatest-testserver-logenricher-pythonasync",
 		message:        "this is a json log from python async",
 	}
+	logEnricherMultiSegWritevConstants = testServerConstants{
+		url:            "http://localhost:8388",
+		smokeEndpoint:  "/smoke",
+		logEndpoint:    "/json_logger",
+		containerImage: "hatest-testserver-logenricher-multiseg-writev",
+		message:        "this is a json log via multi-seg writev",
+	}
 )
 
 // logEnricherTestTraceparents are fixed W3C traceparents used by log enricher tests.
@@ -156,7 +166,7 @@ func testContainerID(t assert.TestingT, cl *client.Client, image string) string 
 func testLogEnricherNodeJS(t *testing.T) {
 	waitForTestComponentsNoMetrics(t, logEnricherNodeJSConstants.url+logEnricherNodeJSConstants.smokeEndpoint)
 
-	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cl, err := client.New(client.FromEnv)
 	require.NoError(t, err)
 	defer cl.Close()
 
@@ -251,7 +261,7 @@ func testLogEnricherNodeJS(t *testing.T) {
 func testLogEnricherJava(t *testing.T) {
 	waitForTestComponentsNoMetrics(t, logEnricherJavaConstants.url+logEnricherJavaConstants.smokeEndpoint)
 
-	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cl, err := client.New(client.FromEnv)
 	require.NoError(t, err)
 	defer cl.Close()
 
@@ -324,7 +334,7 @@ func testLogEnricherJava(t *testing.T) {
 func testLogEnricherRuby(t *testing.T, constants testServerConstants) {
 	waitForTestComponentsNoMetrics(t, constants.url+constants.smokeEndpoint)
 
-	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cl, err := client.New(client.FromEnv)
 	require.NoError(t, err)
 	defer cl.Close()
 
@@ -431,7 +441,7 @@ var pythonAsyncLogEnricherVariants = []struct {
 func testLogEnricherPythonAsync(t *testing.T) {
 	waitForTestComponentsNoMetrics(t, logEnricherPythonAsyncConstants.url+logEnricherPythonAsyncConstants.smokeEndpoint)
 
-	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cl, err := client.New(client.FromEnv)
 	require.NoError(t, err)
 	defer cl.Close()
 
@@ -513,7 +523,7 @@ func testLogEnricherPythonAsyncEndpoint(t *testing.T, cl *client.Client, logEndp
 func testLogEnricherDotNet(t *testing.T) {
 	waitForTestComponentsNoMetrics(t, logEnricherDotNetConstants.url+logEnricherDotNetConstants.smokeEndpoint)
 
-	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cl, err := client.New(client.FromEnv)
 	require.NoError(t, err)
 	defer cl.Close()
 
@@ -577,10 +587,202 @@ func testLogEnricherDotNet(t *testing.T) {
 	}, testTimeout, 500*time.Millisecond)
 }
 
+// testLogEnricherMultiSegWritev exercises the multi-segment ITER_IOVEC path.
+// The C testserver emits JSON log lines via writev(2) split across 3 iovec
+// segments. The BPF logenricher must concatenate all segments to capture the
+// full line; userspace then enriches with trace_id/span_id.
+func testLogEnricherMultiSegWritev(t *testing.T) {
+	waitForTestComponentsNoMetrics(t, logEnricherMultiSegWritevConstants.url+logEnricherMultiSegWritevConstants.smokeEndpoint)
+
+	cl, err := client.New(client.FromEnv)
+	require.NoError(t, err)
+	defer cl.Close()
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		errCh := make(chan error, len(logEnricherTestTraceparents))
+		var wg sync.WaitGroup
+		for _, tp := range logEnricherTestTraceparents {
+			wg.Add(1)
+			go func(tp struct{ traceID, parentID string }) {
+				defer wg.Done()
+				req, err := http.NewRequest(http.MethodGet,
+					logEnricherMultiSegWritevConstants.url+logEnricherMultiSegWritevConstants.logEndpoint, nil)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				req.Header.Set("traceparent", fmt.Sprintf("00-%s-%s-01", tp.traceID, tp.parentID))
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				resp.Body.Close()
+			}(tp)
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			assert.NoError(ct, err, "HTTP request failed")
+		}
+
+		containerID := testContainerID(ct, cl, logEnricherMultiSegWritevConstants.containerImage)
+		if !assert.NotEmpty(ct, containerID, "could not find test container ID") {
+			return
+		}
+		logs := containerLogs(ct, cl, containerID)
+		if !assert.NotEmpty(ct, logs) {
+			return
+		}
+
+		lastSpanID := make(map[string]string, len(logEnricherTestTraceparents))
+		for _, line := range logs {
+			var fields map[string]string
+			if json.Unmarshal([]byte(line), &fields) != nil {
+				continue
+			}
+			if fields["message"] != logEnricherMultiSegWritevConstants.message {
+				continue
+			}
+			if tid, ok := fields["trace_id"]; ok {
+				lastSpanID[tid] = fields["span_id"]
+			}
+		}
+
+		for _, tp := range logEnricherTestTraceparents {
+			spanID, found := lastSpanID[tp.traceID]
+			assert.True(ct, found, "no enriched log line found for trace_id %s", tp.traceID)
+			if found {
+				assert.NotEmpty(ct, spanID, "span_id missing for trace_id %s", tp.traceID)
+			}
+		}
+	}, testTimeout, 500*time.Millisecond)
+}
+
+// testLogEnricherShipperFilters validates the otelcol and fluent-bit filter
+// configs documented in devdocs/trace-log-correlation.md actually drop the
+// NUL-stuffed empty lines that the BPF logenricher leaves on stdout, while
+// passing through the OBI-enriched JSON lines unchanged.
+func testLogEnricherShipperFilters(t *testing.T) {
+	type shipper struct {
+		name     string
+		filePath string
+	}
+	shippers := []shipper{
+		{name: "otelcol", filePath: path.Join(pathOutput, "multiseg-shipper-output", "otelcol-filtered.json")},
+		{name: "fluent-bit", filePath: path.Join(pathOutput, "multiseg-shipper-output", "fluentbit-filtered.json")},
+	}
+
+	for _, sh := range shippers {
+		t.Run(sh.name, func(t *testing.T) {
+			require.EventuallyWithT(t, func(ct *assert.CollectT) {
+				data, err := os.ReadFile(sh.filePath)
+				if !assert.NoError(ct, err) {
+					return
+				}
+				if !assert.NotEmpty(ct, data, "shipper produced no filtered output yet") {
+					return
+				}
+
+				// No NUL-only lines (the suppression pattern) should survive
+				// the documented filter
+				nulLine := regexp.MustCompile(`^[\x00\s]*$`)
+				scanner := bufio.NewScanner(strings.NewReader(string(data)))
+				scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+				for scanner.Scan() {
+					line := scanner.Text()
+					if line == "" {
+						continue
+					}
+					assert.False(ct, nulLine.MatchString(line),
+						"%s output still contains a NUL/whitespace-only line — filter is incorrect", sh.name)
+				}
+				assert.NoError(ct, scanner.Err(), "%s output scan failed", sh.name)
+
+				// Every test traceparent should appear at least once as an
+				// OBI-injected `"trace_id":"<id>"` field. Both fluent-bit
+				// (docker JSON) and otelcol (OTLP attributes[log]) emit the
+				// log content as a JSON-encoded string, so the literal
+				// substring on disk is `\"trace_id\":\"<id>\"`. This guards
+				// against the app's own `traceparent_seen` field satisfying
+				// a plain hex-only `Contains(data, hex)` check
+				for _, tp := range logEnricherTestTraceparents {
+					needle := fmt.Sprintf(`\"trace_id\":\"%s\"`, tp.traceID)
+					assert.Contains(ct, string(data), needle,
+						"%s output missing enriched line for trace_id %s", sh.name, tp.traceID)
+				}
+			}, testTimeout, 1*time.Second)
+
+			// Dump the multiseg testserver's `log` field one-per-line, quoted
+			// so embedded newlines, NUL bytes and empty entries are visible.
+			// fluent-bit emits docker JSON ({"log":"..","stream":..,..}) and
+			// otelcol's file exporter emits OTLP JSON whose body.stringValue
+			// holds the same docker JSON envelope — parse both shapes.
+			// Filter by content to avoid drowning the test log in OBI/Java/
+			// Docker chatter from sibling containers
+			data, err := os.ReadFile(sh.filePath)
+			require.NoError(t, err)
+			t.Logf("=== %s app logs from multiseg_writev (%d bytes raw) ===", sh.name, len(data))
+			dump := bufio.NewScanner(strings.NewReader(string(data)))
+			dump.Buffer(make([]byte, 1024*1024), 1024*1024)
+			lineNo := 0
+			for dump.Scan() {
+				logField := extractShipperLog(dump.Bytes())
+				// match only the multiseg testserver's actual stdout/stderr
+				// output (not OBI BPFLogger lines that happen to contain
+				// `comm=multiseg_writev`)
+				if !strings.Contains(logField, logEnricherMultiSegWritevConstants.message) &&
+					!strings.HasPrefix(logField, "multiseg_writev listening") {
+					continue
+				}
+				lineNo++
+				t.Logf("[%4d] %q", lineNo, logField)
+			}
+			require.NoError(t, dump.Err(), "%s output dump scan failed", sh.name)
+		})
+	}
+}
+
+// extractShipperLog returns the `log` field from a single shipper output
+// record. Handles fluent-bit's docker-shape lines and otelcol's OTLP
+// stringValue wrapper. Returns the raw line as a fallback
+func extractShipperLog(line []byte) string {
+	var docker struct {
+		Log string `json:"log"`
+	}
+	if err := json.Unmarshal(line, &docker); err == nil && docker.Log != "" {
+		return docker.Log
+	}
+	var otlp struct {
+		ResourceLogs []struct {
+			ScopeLogs []struct {
+				LogRecords []struct {
+					Body struct {
+						StringValue string `json:"stringValue"`
+					} `json:"body"`
+				} `json:"logRecords"`
+			} `json:"scopeLogs"`
+		} `json:"resourceLogs"`
+	}
+	if err := json.Unmarshal(line, &otlp); err == nil &&
+		len(otlp.ResourceLogs) > 0 &&
+		len(otlp.ResourceLogs[0].ScopeLogs) > 0 &&
+		len(otlp.ResourceLogs[0].ScopeLogs[0].LogRecords) > 0 {
+		body := otlp.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Body.StringValue
+		// otelcol's body holds the docker JSON envelope as a string —
+		// unwrap one more level to surface the actual log line
+		if err := json.Unmarshal([]byte(body), &docker); err == nil && docker.Log != "" {
+			return docker.Log
+		}
+		return body
+	}
+	return string(line)
+}
+
 func testLogEnricher(t *testing.T, constants testServerConstants) {
 	waitForTestComponentsNoMetrics(t, constants.url+constants.smokeEndpoint)
 
-	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cl, err := client.New(client.FromEnv)
 	require.NoError(t, err)
 	defer cl.Close()
 

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -900,6 +900,22 @@ func TestSuite_LogEnricherPythonAsync(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_LogEnricherMultiSegWritev(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-log-enricher.yml", path.Join(pathOutput, "test-suite-log-enricher-multiseg-writev.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8388`, `OTEL_EBPF_EXECUTABLE_PATH=`)
+	require.NoError(t, compose.Up())
+
+	t.Run("Log Enricher multi-seg writev", func(t *testing.T) {
+		testLogEnricherMultiSegWritev(t)
+	})
+	t.Run("Log Enricher shipper filters", func(t *testing.T) {
+		testLogEnricherShipperFilters(t)
+	})
+	require.NoError(t, compose.Close())
+}
+
 // The idea behind this test suite is to make sure that when an HTTP request is bigger than 1KB,
 // the traceparent is detected and parsed correctly during an ingress flow (protocol_http kprob)
 // and an egress flow (tpinjector sk_msg kprobe).


### PR DESCRIPTION
## Summary

Describe the change briefly.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
