### PR TITLE
Fix stats RTT otel buckets + Make stats test use native OTLP export

### DIFF
--- a/internal/test/integration/configs/prometheus-config-promscrape-otel.yml
+++ b/internal/test/integration/configs/prometheus-config-promscrape-otel.yml
@@ -1,0 +1,11 @@
+global:
+  evaluation_interval: 250ms
+  scrape_interval: 250ms
+scrape_configs:
+  # Scrape the otelcol's Prometheus exporter, which re-exposes metrics that
+  # OBI pushes via OTLP.
+  - job_name: otel
+    honor_labels: true
+    static_configs:
+      - targets:
+          - 'otelcol:9464'

--- a/internal/test/integration/red_test_stat_metrics.go
+++ b/internal/test/integration/red_test_stat_metrics.go
@@ -14,20 +14,24 @@ import (
 )
 
 func testStatMetricsTCPRtt(t *testing.T, port string) {
-	// Eventually, Prometheus would make this query visible
 	pq := promtest.Client{HostPort: prometheusHostPort}
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		// Observations should appear above the 100ms bucket (pumba injects 100ms delay)
-		bucketAt100ms, err := pq.Query(`obi_stat_tcp_rtt_seconds_bucket{dst_port="` + port + `",le="0.1"}`)
-		require.NoError(ct, err)
-		enoughPromResults(ct, bucketAt100ms)
-
 		countResults, err := pq.Query(`obi_stat_tcp_rtt_seconds_count{dst_port="` + port + `"}`)
 		require.NoError(ct, err)
 		enoughPromResults(ct, countResults)
 
-		// if pumba is working, not all observations fit in the <=100ms bucket
-		assert.Less(ct, totalPromCount(ct, bucketAt100ms), totalPromCount(ct, countResults))
+		// pumba injects a 100ms delay on the testclient, so the average
+		// observed RTT (sum/count, aggregated across all matching series)
+		// should be at or above 100ms. The threshold is folded into the
+		// PromQL: a comparison operator filters the result, so a non-empty
+		// response means "the average exists and is >= 100ms". Asserting on
+		// the average rather than a specific bucket boundary keeps the test
+		// independent of the histogram's exact bucket layout.
+		avgQuery := `sum(obi_stat_tcp_rtt_seconds_sum{dst_port="` + port + `"}) /` +
+			` sum(obi_stat_tcp_rtt_seconds_count{dst_port="` + port + `"}) >= 0.1`
+		avgResults, err := pq.Query(avgQuery)
+		require.NoError(ct, err)
+		enoughPromResults(ct, avgResults)
 	}, testTimeout, 100*time.Millisecond)
 }
 

--- a/internal/test/integration/red_test_stat_metrics.go
+++ b/internal/test/integration/red_test_stat_metrics.go
@@ -49,7 +49,7 @@ func testStatMetricsTCPRttGo(t *testing.T) {
 func testStatMetricsTCPFailedConnectionGo(t *testing.T) {
 	pq := promtest.Client{HostPort: prometheusHostPort}
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		results, err := pq.Query(`obi_stat_tcp_failed_connections{dst_port="19999",network_tcp_handshake_role="client"}`)
+		results, err := pq.Query(`obi_stat_tcp_failed_connections_total{dst_port="19999",network_tcp_handshake_role="client"}`)
 		require.NoError(ct, err)
 		enoughPromResults(ct, results)
 		assert.Positive(ct, totalPromCount(ct, results))

--- a/internal/test/integration/suites_stat_test.go
+++ b/internal/test/integration/suites_stat_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestStat_GoStatMetrics(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-go-stat-metrics.yml", path.Join(pathOutput, "test-suite-go-stat-metrics.log"))
-	compose.Env = append(compose.Env, `TEST_SERVICE_PORTS=8381:8080`, `OTEL_EBPF_CONFIG_SUFFIX=-go-stat-metrics`, `PROM_CONFIG_SUFFIX=-promscrape`)
+	compose.Env = append(compose.Env, `TEST_SERVICE_PORTS=8381:8080`, `OTEL_EBPF_CONFIG_SUFFIX=-go-stat-metrics`, `PROM_CONFIG_SUFFIX=-promscrape-otel`)
 	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 	t.Run("Go Stat Metrics TCP RTT tests", testStatMetricsTCPRttGo)

--- a/pkg/export/otel/metrics_stats.go
+++ b/pkg/export/otel/metrics_stats.go
@@ -135,7 +135,11 @@ func newStatMetricsExporter(
 	if cfg.CommonCfg.Features.StatsTCPRtt() {
 		log := log.With("metricFamily", "StatsTCPRtt")
 
-		tcpRtt, err := ebpfEvents.Float64Histogram(attributes.StatTCPRtt.OTEL, metric2.WithUnit("s"))
+		tcpRtt, err := ebpfEvents.Float64Histogram(
+			attributes.StatTCPRtt.OTEL,
+			metric2.WithUnit("s"),
+			metric2.WithExplicitBucketBoundaries(0.0005, 0.001, 0.002, 0.005, 0.010, 0.025, 0.050, 0.100, 0.250, 0.500, 1.0),
+		)
 		if err != nil {
 			log.Error("creating stats tcp rtt histogram", "error", err)
 			return nil, err


### PR DESCRIPTION
## Summary

Currently when exporting stats RTT metrics via otlp the buckets dont really make sense for this ms operation.

Changes Made
- Match Otel histogram buckets to match promethues buckets for TCP RTT metric
- Changed integration test to evaluate against otlp exported metrics instead of prometheus metrics
- Changed the test not to rely on an exact le=0.1, since it is fragile and depends on the histogras exact buckets, changed it to avg

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
