### PR TITLE
k8s integration: enforce weaver semconv live-check in all OTLP-exporting suites

### DIFF
--- a/internal/test/integration/components/kube/kind.go
+++ b/internal/test/integration/components/kube/kind.go
@@ -59,6 +59,22 @@ type Kind struct {
 	logsDir         string
 	promEndpoint    string
 	jaegerEndpoint  string
+
+	weaverValidation bool
+	// weaverRequireSpans additionally fails the suite if the weaver report
+	// carries no span samples. For trace-enabled suites a metrics-only report
+	// means the trace export never reached weaver (e.g. traces routed straight
+	// to jaeger instead of through the tapped otelcol), so span-specific
+	// semconv violations would silently go unvalidated.
+	weaverRequireSpans bool
+	// weaverFailed is set by validateWeaverFinish and checked by Run:
+	// e2e-framework drops Finish errors from the exit code, so weaver
+	// enforcement has to flow through the Kind itself.
+	weaverFailed bool
+	// Tap export-failure counter captured before tests (waitForWeaverReady),
+	// compared at teardown by validateWeaver.
+	tapDropsBaseline    float64
+	tapDropsBaselineErr error
 }
 
 // Option that can be passed to the NewKind function in order to change the configuration
@@ -117,6 +133,34 @@ func LocalImage(nameTag string) Option {
 	}
 }
 
+// WeaverValidation makes the suite validate the telemetry received by the
+// in-cluster weaver pod against the OBI semconv registry, at teardown (after
+// all tests, while the cluster is still up). Enforcing: any actionable
+// advisory makes the suite exit non-zero. Requires the weaver manifests to be
+// deployed (see validateWeaver for the full wiring).
+func WeaverValidation(opts ...WeaverOption) Option {
+	return func(k *Kind) {
+		k.weaverValidation = true
+		for _, o := range opts {
+			o(k)
+		}
+	}
+}
+
+// WeaverOption tunes WeaverValidation.
+type WeaverOption func(k *Kind)
+
+// WeaverRequireSpans additionally fails the suite when the weaver report holds
+// no span samples. Pass it for suites that route OBI traces through the weaver
+// tap: it guards against the report silently degrading to metrics-only (the
+// trace path broken or bypassing the tap), which would leave span semconv
+// violations unvalidated while the suite still passed.
+func WeaverRequireSpans() WeaverOption {
+	return func(k *Kind) {
+		k.weaverRequireSpans = true
+	}
+}
+
 // NewKind creates a kind cluster given a name and set of Option instances.
 func NewKind(kindClusterName string, options ...Option) *Kind {
 	k := &Kind{
@@ -155,17 +199,42 @@ func (k *Kind) Run(m *testing.M) {
 		log.Info("adding func: deployManifests", "manifest", mf)
 		funcs = append(funcs, deploy(mf))
 	}
+	if k.weaverValidation {
+		// Gate the tests on the weaver tap being up, so bursty test-time
+		// telemetry (spans) is observed rather than lost while weaver is still
+		// pulling its image.
+		log.Info("adding func: waitForWeaverReady")
+		funcs = append(funcs, k.waitForWeaverReady())
+	}
+
+	var finishes []env.Func
+	if k.weaverValidation {
+		log.Info("adding finish func: validateWeaver")
+		finishes = append(finishes, k.validateWeaverFinish())
+	}
+	finishes = append(finishes,
+		k.exportLogs(),
+		k.exportAllMetrics(),
+		k.exportAllTraces(),
+		k.deleteLabeled(),
+		envfuncs.DestroyCluster(k.clusterName),
+	)
 
 	log.Info("starting kind setup")
 	code := k.testEnv.Setup(funcs...).
-		Finish(
-			k.exportLogs(),
-			k.exportAllMetrics(),
-			k.exportAllTraces(),
-			k.deleteLabeled(),
-			envfuncs.DestroyCluster(k.clusterName),
-		).Run(m)
+		Finish(finishes...).Run(m)
 	log.With("returnCode", code).Info("tests finished run")
+	if k.weaverFailed && code == 0 {
+		log.Error("weaver semconv validation failed — failing the suite")
+		code = 1
+	}
+	// A setup failure (cluster creation, image load, manifest deploy) surfaces
+	// only in env.Run's return code: no test has run, so a plain return from
+	// TestMain would make the binary exit 0 and the suite would silently pass.
+	// Same for a weaver validation failure at teardown.
+	if code != 0 {
+		os.Exit(code)
+	}
 }
 
 // export logs into the e2e-logs folder of the base directory.

--- a/internal/test/integration/components/kube/weaver.go
+++ b/internal/test/integration/components/kube/weaver.go
@@ -231,8 +231,8 @@ func (k *Kind) validateWeaver(parent context.Context, t weavercheck.TestingT) {
 	}
 
 	if k.weaverRequireSpans && report.Statistics.TotalEntitiesByType["span"] == 0 {
-		t.Errorf("weaver report has no span entities — OBI's trace export is not reaching weaver "+
-			"(is OTEL_EXPORTER_OTLP_TRACES_ENDPOINT pointed at the tapped otelcol rather than "+
+		t.Errorf("weaver report has no span entities — OBI's trace export is not reaching weaver " +
+			"(is OTEL_EXPORTER_OTLP_TRACES_ENDPOINT pointed at the tapped otelcol rather than " +
 			"straight at jaeger?); span semconv violations would otherwise go unvalidated")
 	}
 

--- a/internal/test/integration/components/kube/weaver.go
+++ b/internal/test/integration/components/kube/weaver.go
@@ -216,18 +216,18 @@ func (k *Kind) validateWeaver(parent context.Context, t weavercheck.TestingT) {
 		}
 	}
 
-	// A dropped export may have carried the sole sample of a violating shape, so
-	// any drop during the suite — or an unreadable counter — makes the report
-	// untrustworthy.
+	// A first-hop drop may have carried the sole sample of a violating shape, so
+	// any such drop during the suite — or an unreadable counter — makes the
+	// report untrustworthy.
 	if k.tapDropsBaselineErr != nil || finalDropsErr != nil {
 		t.Errorf("could not read the tap's export-failure counters (baseline: %v, teardown: %v) — "+
 			"cannot confirm weaver saw every emitted shape, so the report is untrustworthy",
 			k.tapDropsBaselineErr, finalDropsErr)
 	} else if dropped := finalDrops - k.tapDropsBaseline; dropped > 0 {
-		t.Errorf("the weaver tap dropped %.0f export item(s) during the suite "+
-			"(otelcol_exporter_{send,enqueue}_failed_* across the suite otelcol and weavercol) — "+
-			"weaver may have missed a telemetry shape, so the report cannot be trusted; reduce "+
-			"OBI's emission rate or raise the tap queue sizes", dropped)
+		t.Errorf("the suite otelcol dropped %.0f export item(s) to weavercol during the suite "+
+			"(otelcol_exporter_{send,enqueue}_failed_*) — weaver may have missed a telemetry "+
+			"shape, so the report cannot be trusted; reduce OBI's emission rate or raise the "+
+			"first-hop tap queue size", dropped)
 	}
 
 	if k.weaverRequireSpans && report.Statistics.TotalEntitiesByType["span"] == 0 {
@@ -239,18 +239,14 @@ func (k *Kind) validateWeaver(parent context.Context, t weavercheck.TestingT) {
 	weavercheck.Validate(t, report)
 }
 
-// tapDropCount sums the export failures of both tap hops (suite otelcol ->
-// weavercol -> weaver), erroring if either endpoint can't be scraped.
+// tapDropCount reads the suite otelcol's export failures to weavercol, the
+// first tap hop. Only this hop is a trust signal: weavercol ingests instantly
+// so the first-hop queue never fills, making any failure here a shape that
+// never reached the aggregator. The weavercol -> weaver hop drops by design
+// under weaver back-pressure (otelcol-config-k8s-weavercol.yml), shedding only
+// already-aggregated points weaver has already seen.
 func (k *Kind) tapDropCount(ctx context.Context) (float64, error) {
-	var total float64
-	for _, port := range []int{OtelcolWeaverMetricsHostPort, WeaverColMetricsHostPort} {
-		n, err := exporterFailedCount(ctx, port)
-		if err != nil {
-			return 0, fmt.Errorf("scraping exporter counters on host port %d: %w", port, err)
-		}
-		total += n
-	}
-	return total, nil
+	return exporterFailedCount(ctx, OtelcolWeaverMetricsHostPort)
 }
 
 // exporterFailedCount sums otelcol_exporter_{send,enqueue}_failed_* from a

--- a/internal/test/integration/components/kube/weaver.go
+++ b/internal/test/integration/components/kube/weaver.go
@@ -1,0 +1,322 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kube // import "go.opentelemetry.io/obi/internal/test/integration/components/kube"
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+
+	"go.opentelemetry.io/obi/internal/test/weavercheck"
+)
+
+const (
+	// WeaverK8sAdminHostPort is the host port the kind clusters map weaver's
+	// admin port (4320) to, via the extraPortMapping in manifests/00-kind*.yml.
+	WeaverK8sAdminHostPort = 32320
+
+	// Host ports the kind clusters map the weavercol and suite-otelcol telemetry
+	// endpoints to (00-kind*.yml); validateWeaver scrapes both for tap drops.
+	WeaverColMetricsHostPort     = 32888
+	OtelcolWeaverMetricsHostPort = 32889
+
+	// weaverK8sTimeout bounds the wait-for-weaver + /stop + report-read
+	// sequence. Report generation scales with the number of unique samples
+	// weaver received; the interval processor in
+	// otelcol-config-k8s-weavercol.yml keeps that bounded, but
+	// high-cardinality suites (netolly) still need a generous margin.
+	weaverK8sTimeout = 6 * time.Minute
+
+	// weaverK8sDrainWindow is how long validateWeaver waits after weaver is
+	// reachable before stopping it: it must cover the weavercol `interval`
+	// processor tick (10s, see otelcol-config-k8s-weavercol.yml) plus gRPC
+	// reconnect backoff, so at least one aggregated batch arrives.
+	weaverK8sDrainWindow = 25 * time.Second
+
+	// weaverK8sEmptyReportAttempts is how many /stop + read cycles to try
+	// when the report comes back with zero samples (each cycle restarts the
+	// weaver pod and drains again).
+	weaverK8sEmptyReportAttempts = 3
+
+	// weaverK8sReadyTimeout bounds the pre-test wait for the weaver tap to come
+	// up (see waitForWeaverReady). It is generous because weaver and weavercol
+	// pull their images from the network on a cold CI node.
+	weaverK8sReadyTimeout = 5 * time.Minute
+)
+
+// weaverRecorder adapts weavercheck.TestingT to the suite-teardown context,
+// where no *testing.T exists (e2e-framework Finish funcs run after m.Run()
+// has returned). Failures are recorded and logged at default slog verbosity —
+// deliberately NOT relying on the framework's handling of Finish errors,
+// which are logged at klog V(2) only and dropped from the exit code.
+type weaverRecorder struct {
+	failed bool
+}
+
+func (r *weaverRecorder) Helper() {}
+
+// Logf/Errorf are the single place a "weaver(k8s):" prefix is applied, so the
+// shared weavercheck.Validate output (which is prefix-less, being reused by the
+// non-k8s compose/OATS suites) is tagged consistently. validateWeaver's own
+// messages therefore must NOT repeat the prefix, or it would double up.
+func (r *weaverRecorder) Logf(format string, args ...any) {
+	log().Info("weaver(k8s): " + fmt.Sprintf(format, args...))
+}
+
+func (r *weaverRecorder) Errorf(format string, args ...any) {
+	r.failed = true
+	log().Error("weaver(k8s): " + fmt.Sprintf(format, args...))
+}
+
+// FailNow mirrors testing.T.FailNow for the require calls inside
+// weavercheck.Validate: validateWeaverFinish runs the validation on a
+// dedicated goroutine precisely so this Goexit aborts only the validation.
+func (r *weaverRecorder) FailNow() {
+	r.failed = true
+	runtime.Goexit()
+}
+
+// waitForWeaverReady is a setup func (registered before the suite's tests run,
+// see Kind.Run) that blocks until the weaver tap is reachable. Spans are bursty
+// — OBI emits them only while the tests drive traffic — so if weaver is still
+// pulling its image when the tests start, every span is dropped before it and
+// the teardown report degrades to the continuously-emitted metrics only. The
+// metric stream would still make the report non-empty, hiding the gap, so the
+// readiness gate is what actually lets validateWeaver observe spans. Waits on
+// both the weaver admin port and weavercol's telemetry endpoint (the two
+// host-mapped hops of the tap); the suite otelcol comes up from a local image
+// well before either.
+func (k *Kind) waitForWeaverReady() env.Func {
+	return func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+		wctx, cancel := context.WithTimeout(ctx, weaverK8sReadyTimeout)
+		defer cancel()
+		weaverURL := fmt.Sprintf("http://127.0.0.1:%d/", WeaverK8sAdminHostPort)
+		if err := waitForHTTP(wctx, weaverURL); err != nil {
+			return ctx, fmt.Errorf("weaver admin port not ready before tests: %w", err)
+		}
+		weavercolURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", WeaverColMetricsHostPort)
+		if err := waitForHTTP(wctx, weavercolURL); err != nil {
+			return ctx, fmt.Errorf("weavercol not ready before tests: %w", err)
+		}
+		otelcolURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", OtelcolWeaverMetricsHostPort)
+		if err := waitForHTTP(wctx, otelcolURL); err != nil {
+			return ctx, fmt.Errorf("suite otelcol telemetry not ready before tests: %w", err)
+		}
+		// Baseline for validateWeaver's teardown drop check (before any traffic).
+		k.tapDropsBaseline, k.tapDropsBaselineErr = k.tapDropCount(wctx)
+		log().Info("weaver(k8s): tap ready, starting tests")
+		return ctx, nil
+	}
+}
+
+// validateWeaverFinish is the Finish func registered — first, while the
+// cluster is still up — when a suite opts in via the WeaverValidation option.
+// e2e-framework gives Finish funcs no way to fail the suite, so enforcement
+// happens out of band: the failure is recorded on the Kind and Run turns it
+// into a non-zero exit.
+func (k *Kind) validateWeaverFinish() env.Func {
+	return func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+		rec := &weaverRecorder{}
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			k.validateWeaver(ctx, rec)
+		}()
+		<-done
+		// Record only — never return an error: every func registered in the
+		// single .Finish() call of Kind.Run belongs to one e2e-framework
+		// action, and an action stops at its first failing func, which would
+		// skip log export, the OBI coverage flush and DestroyCluster.
+		// Enforcement happens via Kind.Run's exit code instead.
+		k.weaverFailed = rec.failed
+		return ctx, nil
+	}
+}
+
+// validateWeaver stops the in-cluster weaver pod (HTTP POST /stop on its
+// host-exposed admin port) and validates the live-check report weaver returns
+// in the /stop response body (weaver runs with --output http). It runs at suite
+// teardown (see validateWeaverFinish), after every test but before the cluster
+// is destroyed.
+//
+// Requirements (wired in the suite's manifests):
+//   - a weaver pod (manifests/08-weaver*.yml) mounting /obi-registry from the
+//     kind `obi-registry` extraMount;
+//   - an OTLP-exporting otelcol that taps weaver (03-otelcol-weaver*.yml);
+//   - the kind config (00-kind*.yml) with the weaver admin extraPortMapping
+//     4320 -> WeaverK8sAdminHostPort.
+func (k *Kind) validateWeaver(parent context.Context, t weavercheck.TestingT) {
+	t.Helper()
+
+	// Derive from the Finish context so an aborted suite cancels validation
+	// instead of blocking up to weaverK8sTimeout.
+	ctx, cancel := context.WithTimeout(parent, weaverK8sTimeout)
+	defer cancel()
+
+	// The weaver pod is deployed with the rest of the suite but pulls its
+	// image from the network, so on a cold node it may become Ready only
+	// after the suite's tests have already started (nothing in the suite
+	// depends on it before this point). Wait for its host-mapped admin port
+	// to answer, then leave a drain window covering the weavercol `interval`
+	// processor tick plus gRPC reconnect backoff, so at least one aggregated
+	// batch reaches weaver before we stop it.
+	addr := fmt.Sprintf("127.0.0.1:%d", WeaverK8sAdminHostPort)
+	if err := waitForHTTP(ctx, "http://"+addr+"/"); err != nil {
+		t.Errorf("admin port %s never became reachable (weaver pod not running?): %v", addr, err)
+		return
+	}
+
+	// Lifetime counters at end of tests, before the /stop loop restarts weaver.
+	finalDrops, finalDropsErr := k.tapDropCount(ctx)
+
+	// A weaver that came up mid-suite may still produce an empty report on
+	// the first /stop (the tap was reconnecting / the interval tick had not
+	// flushed). Stopping weaver makes its pod restart (default restartPolicy),
+	// and OBI keeps emitting until teardown, so simply draining again and
+	// re-fetching from the restarted instance recovers — retry a couple of
+	// times before declaring the tap pipeline broken.
+	adminURL := fmt.Sprintf("http://%s/stop", addr)
+	var report *weavercheck.Report
+	for attempt := 1; ; attempt++ {
+		select {
+		case <-time.After(weaverK8sDrainWindow):
+		case <-ctx.Done():
+		}
+
+		var err error
+		report, err = weavercheck.FetchReport(ctx, adminURL)
+		if err != nil {
+			t.Errorf("%v", err)
+			return
+		}
+		if report.Statistics.TotalEntities > 0 {
+			break
+		}
+		if attempt >= weaverK8sEmptyReportAttempts {
+			t.Errorf("live-check report has no entities after %d attempts — weaver received "+
+				"no telemetry (is the otelcol weaver tap pipeline broken?)", attempt)
+			return
+		}
+		t.Logf("empty report on attempt %d/%d, waiting for the restarted weaver to receive telemetry",
+			attempt, weaverK8sEmptyReportAttempts)
+		// The restarted weaver pod needs to be answering again before the
+		// next /stop.
+		if err := waitForHTTP(ctx, "http://"+addr+"/"); err != nil {
+			t.Errorf("restarted weaver never became reachable: %v", err)
+			return
+		}
+	}
+
+	// A dropped export may have carried the sole sample of a violating shape, so
+	// any drop during the suite — or an unreadable counter — makes the report
+	// untrustworthy.
+	if k.tapDropsBaselineErr != nil || finalDropsErr != nil {
+		t.Errorf("could not read the tap's export-failure counters (baseline: %v, teardown: %v) — "+
+			"cannot confirm weaver saw every emitted shape, so the report is untrustworthy",
+			k.tapDropsBaselineErr, finalDropsErr)
+	} else if dropped := finalDrops - k.tapDropsBaseline; dropped > 0 {
+		t.Errorf("the weaver tap dropped %.0f export item(s) during the suite "+
+			"(otelcol_exporter_{send,enqueue}_failed_* across the suite otelcol and weavercol) — "+
+			"weaver may have missed a telemetry shape, so the report cannot be trusted; reduce "+
+			"OBI's emission rate or raise the tap queue sizes", dropped)
+	}
+
+	if k.weaverRequireSpans && report.Statistics.TotalEntitiesByType["span"] == 0 {
+		t.Errorf("weaver report has no span entities — OBI's trace export is not reaching weaver "+
+			"(is OTEL_EXPORTER_OTLP_TRACES_ENDPOINT pointed at the tapped otelcol rather than "+
+			"straight at jaeger?); span semconv violations would otherwise go unvalidated")
+	}
+
+	weavercheck.Validate(t, report)
+}
+
+// tapDropCount sums the export failures of both tap hops (suite otelcol ->
+// weavercol -> weaver), erroring if either endpoint can't be scraped.
+func (k *Kind) tapDropCount(ctx context.Context) (float64, error) {
+	var total float64
+	for _, port := range []int{OtelcolWeaverMetricsHostPort, WeaverColMetricsHostPort} {
+		n, err := exporterFailedCount(ctx, port)
+		if err != nil {
+			return 0, fmt.Errorf("scraping exporter counters on host port %d: %w", port, err)
+		}
+		total += n
+	}
+	return total, nil
+}
+
+// exporterFailedCount sums otelcol_exporter_{send,enqueue}_failed_* from a
+// collector's telemetry endpoint on the given host port.
+func exporterFailedCount(ctx context.Context, hostPort int) (float64, error) {
+	url := fmt.Sprintf("http://127.0.0.1:%d/metrics", hostPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+	var total float64
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, "otelcol_exporter_send_failed_") &&
+			!strings.HasPrefix(line, "otelcol_exporter_enqueue_failed_") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		v, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err != nil {
+			continue
+		}
+		total += v
+	}
+	return total, nil
+}
+
+// waitForHTTP polls url until the server produces any HTTP response (status
+// irrelevant) or ctx expires. A plain TCP dial is not enough: the kind
+// extraPortMapping accepts connections even while the target hostPort has no
+// running backend and only resets them on use, so readiness requires an
+// HTTP-level round trip.
+func waitForHTTP(ctx context.Context, url string) error {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	var lastErr error
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			return nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%w (last probe error: %w)", ctx.Err(), lastErr)
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/test/integration/components/testserver/std/std.go
+++ b/internal/test/integration/components/testserver/std/std.go
@@ -309,12 +309,28 @@ func rolldice(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "%v", n)
 }
 
+// rolldicePost handles POST /rolldice/{id} and returns a JSON response body so
+// that HTTP response-body extraction has non-empty JSON content to capture.
+func rolldicePost(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	n := rd.IntN(6) + 1
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Dice-Roll", strconv.Itoa(n))
+
+	slog.Info("rolldice POST called", "id", id, "dice", n)
+
+	fmt.Fprintf(w, `{"result":%d}`, n)
+}
+
 func Setup(port int) {
 	log := slog.With("component", "std.Server")
 	address := fmt.Sprintf(":%d", port)
 	log.Info("starting HTTP server", "address", address)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /rolldice/{id}", rolldice)
+	mux.HandleFunc("POST /rolldice/{id}", rolldicePost)
 	mux.HandleFunc("/", HTTPHandler(log, port))
 
 	err := http.ListenAndServe(address, mux)
@@ -328,6 +344,7 @@ func SetupTLS(port int) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /rolldice/{id}", rolldice)
+	mux.HandleFunc("POST /rolldice/{id}", rolldicePost)
 	mux.HandleFunc("/", HTTPHandler(log, port))
 
 	err := http.ListenAndServeTLS(address, "x509/server_test_cert.pem", "x509/server_test_key.pem", mux)

--- a/internal/test/integration/configs/obi-config-http-enrichment-body.yml
+++ b/internal/test/integration/configs/obi-config-http-enrichment-body.yml
@@ -9,7 +9,7 @@ routes:
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4318
 attributes:
   select:
     "*":
@@ -72,10 +72,10 @@ ebpf:
             match:
               url_path_patterns:
                 - "/smoke"
-          # Include body on specific route without obfuscation
+          # Include request + response body on specific route without obfuscation
           - action: include
             type: body
-            scope: request
+            scope: all
             match:
               methods: ["POST"]
               url_path_patterns:

--- a/internal/test/integration/configs/obi-config-netolly-direction.yml
+++ b/internal/test/integration/configs/obi-config-netolly-direction.yml
@@ -1,5 +1,7 @@
 network:
   guess_ports: ordinal
+  cidrs:
+  - 0.0.0.0/0
 attributes:
   select:
     obi_network_flow_bytes:
@@ -15,6 +17,8 @@ attributes:
       - dst.namespace
       - src.cidr
       - dst.cidr
+      - transport
+      - network.type
       - iface
       - iface_direction
       - direction

--- a/internal/test/integration/configs/obi-config-promscrape.yml
+++ b/internal/test/integration/configs/obi-config-promscrape.yml
@@ -6,7 +6,7 @@ prometheus_export:
   port: 8999
   features:
     - application
-  extra_resource_attributes: ["deployment_environment"]
+  extra_resource_attributes: ["deployment_environment_name"]
   exemplar_filter: "always_on"
 attributes:
   select:

--- a/internal/test/integration/configs/otelcol-config-k8s-weaver.yml
+++ b/internal/test/integration/configs/otelcol-config-k8s-weaver.yml
@@ -1,0 +1,71 @@
+# otelcol config for the Kubernetes / kind suites with a weaver tap.
+#
+# Mirrors the base k8s `otelcol-config.yml` (OTLP receiver -> prometheus
+# exporter, which the suites poll; same collector image pin) and additionally
+# forwards every metric and trace batch to the intermediate `weavercol`
+# collector (otelcol-config-k8s-weavercol.yml), which aggregates and relays
+# to the weaver pod.
+#
+# Why the extra hop instead of exporting to weaver directly: weaver validates
+# every sample and is slow at netolly-scale cardinality. When THIS collector
+# exported straight to weaver, its sending queue filled and the enqueue
+# failure propagated synchronously through the shared OTLP receiver back to
+# OBI (observed: OBI logging "sending queue is full" while the suite's
+# prometheus queries returned empty). weavercol ingests instantly, so this
+# side's queue never fills; weaver back-pressure surfaces at weavercol, and
+# reaches this collector only as an asynchronous send failure on an already
+# dequeued item — dropped and logged, never failing OBI's export. Sample
+# loss on the weaver side is acceptable: semconv validation only needs to
+# *see* each unique advisory once, not every data point.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        max_recv_msg_size_mib: 100
+      http:
+        endpoint: 0.0.0.0:4318
+        cors:
+          allowed_origins:
+            - "http://*"
+            - "https://*"
+exporters:
+  prometheus:
+    endpoint: "otelcol:9464"
+    resource_to_telemetry_conversion:
+      enabled: true
+    enable_open_metrics: true
+  # Forward traces to jaeger so suites that route OBI traces through this
+  # collector (instead of straight to jaeger) keep their jaeger-based trace
+  # assertions working. Harmless for metrics-only suites (no traces flow).
+  otlphttp/jaeger:
+    endpoint: http://jaeger:4318
+    tls:
+      insecure: true
+  otlp/weavercol:
+    endpoint: weavercol:4317
+    tls:
+      insecure: true
+    sending_queue:
+      enabled: true
+      queue_size: 500
+    retry_on_failure:
+      enabled: false
+service:
+  # own telemetry exposed for validateWeaver's first-hop drop check (00-kind*.yml)
+  telemetry:
+    metrics:
+      address: 0.0.0.0:8888
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/jaeger]
+    metrics/weaver:
+      receivers: [otlp]
+      exporters: [otlp/weavercol]
+    traces/weaver:
+      receivers: [otlp]
+      exporters: [otlp/weavercol]

--- a/internal/test/integration/configs/otelcol-config-k8s-weavercol.yml
+++ b/internal/test/integration/configs/otelcol-config-k8s-weavercol.yml
@@ -1,0 +1,62 @@
+# Intermediate collector between the suite otelcol
+# (otelcol-config-k8s-weaver.yml) and the weaver pod, for the Kubernetes /
+# kind suites. Runs a newer contrib image than the base pin (see
+# 08-weaver*.yml) for the `interval` processor and
+# `sending_queue.block_on_overflow`.
+#
+# Its two jobs:
+#   - Aggregate the high-frequency metric stream (the suites run OBI with a
+#     10ms metrics interval) to one data point per series per tick before it
+#     reaches weaver. Semconv validation needs each unique series shape, not
+#     every data point — without this, netolly-scale suites feed weaver
+#     hundreds of thousands of samples and its report generation takes
+#     minutes.
+#   - Absorb weaver back-pressure: when weaver ingests slower than data
+#     arrives, this collector's queue overflows and drops (never blocks, no
+#     retries), and the failure the upstream otelcol sees is asynchronous —
+#     so nothing propagates back to OBI's export path (see the design note
+#     in otelcol-config-k8s-weaver.yml).
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        max_recv_msg_size_mib: 100
+processors:
+  interval:
+    interval: 10s
+exporters:
+  otlp/weaver:
+    endpoint: weaver:4317
+    tls:
+      insecure: true
+    # weaver's OTLP receiver rejects gzip-compressed payloads
+    compression: none
+    sending_queue:
+      enabled: true
+      queue_size: 500
+      block_on_overflow: false
+    retry_on_failure:
+      enabled: false
+service:
+  # Expose weavercol's own telemetry so the Go harness can read the
+  # exporter's send/enqueue failure counters at teardown: any export dropped
+  # before weaver means the live-check report is missing telemetry and cannot
+  # be trusted (see validateWeaver's dropped-export check). Mapped to the host
+  # via the kind extraPortMapping in 00-kind*.yml.
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [interval]
+      exporters: [otlp/weaver]
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/weaver]

--- a/internal/test/integration/docker-compose-netolly-direction.yml
+++ b/internal/test/integration/docker-compose-netolly-direction.yml
@@ -41,7 +41,7 @@ services:
       OTEL_EBPF_CONFIG_PATH: /configs/obi-config-netolly${OTEL_EBPF_CONFIG_SUFFIX}.yml
       GOCOVERDIR: "/coverage"
       OTEL_EBPF_NETWORK_SOURCE: ${OTEL_EBPF_NETWORK_SOURCE}
-      OTEL_EBPF_METRICS_FEATURES: "network" # implicitly enabling network metrics without a global enable
+      OTEL_EBPF_METRICS_FEATURES: "network,network_flow_packets,network_inter_zone" # implicitly enabling network metrics without a global enable
       OTEL_EBPF_NETWORK_PRINT_FLOWS: "true"
       OTEL_EBPF_METRICS_INTERVAL: "1s"
       OTEL_EBPF_BPF_BATCH_TIMEOUT: "1s"

--- a/internal/test/integration/http_enrichment_body_test.go
+++ b/internal/test/integration/http_enrichment_body_test.go
@@ -20,7 +20,7 @@ import (
 
 // bodyExtractionObfuscate verifies that the body extraction rules correctly
 // capture the request body with sensitive fields obfuscated.
-func bodyExtractionObfuscate(t *testing.T) {
+func bodyExtractionObfuscate(t *testing.T, postOperation string) {
 	// Send POST requests with a JSON body containing sensitive fields.
 	// The config obfuscates $.password and $.secret with "***", credit-card
 	// fields with "PCI", and social/insurance numbers with "PII" on POST requests.
@@ -31,7 +31,7 @@ func bodyExtractionObfuscate(t *testing.T) {
 
 	var trace jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=POST%20%2Frolldice%2F%3Aid")
+		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=" + url.QueryEscape(postOperation))
 		require.NoError(ct, err)
 		if resp == nil {
 			return
@@ -45,7 +45,7 @@ func bodyExtractionObfuscate(t *testing.T) {
 		trace = traces[0]
 	}, testTimeout, 100*time.Millisecond)
 
-	res := trace.FindByOperationName("POST /rolldice/:id", "server")
+	res := trace.FindByOperationName(postOperation, "server")
 	require.NotEmpty(t, res)
 	span := res[0]
 
@@ -74,7 +74,7 @@ func bodyExtractionObfuscate(t *testing.T) {
 
 // bodyExtractionInclude verifies that body include rules capture the raw body
 // without obfuscation when only an include rule matches.
-func bodyExtractionInclude(t *testing.T) {
+func bodyExtractionInclude(t *testing.T, postOperation string) {
 	// The config has an include rule for POST /rolldice/* which also matches,
 	// but the obfuscate rule also matches POST requests.
 	// Since body rules merge, both rules apply: obfuscate paths are applied
@@ -88,7 +88,7 @@ func bodyExtractionInclude(t *testing.T) {
 
 	var trace jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=POST%20%2Frolldice%2F%3Aid")
+		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=" + url.QueryEscape(postOperation))
 		require.NoError(ct, err)
 		if resp == nil {
 			return
@@ -102,7 +102,7 @@ func bodyExtractionInclude(t *testing.T) {
 		trace = traces[0]
 	}, testTimeout, 100*time.Millisecond)
 
-	res := trace.FindByOperationName("POST /rolldice/:id", "server")
+	res := trace.FindByOperationName(postOperation, "server")
 	require.NotEmpty(t, res)
 	span := res[0]
 
@@ -113,6 +113,13 @@ func bodyExtractionInclude(t *testing.T) {
 	require.True(t, valOk)
 	assert.Contains(t, val, "roll", "action field should be present")
 	assert.Contains(t, val, "6", "sides field should be present")
+
+	// Verify the JSON response body content is captured (response-scope include rule).
+	respTag, respOk := jaeger.FindIn(span.Tags, "http.response.body.content")
+	require.True(t, respOk, "expected http.response.body.content on span")
+	respVal, respValOk := jaeger.TagFirstStringValue(respTag)
+	require.True(t, respValOk)
+	assert.Contains(t, respVal, "result", "response body result field should be present")
 }
 
 // bodyExtractionExcludedByDefault verifies that GET requests (which don't match
@@ -151,7 +158,7 @@ func bodyExtractionExcludedByDefault(t *testing.T, getOperation string) {
 
 // bodyExtractionContentTypeHeader verifies that the Content-Type header
 // is also included on the span (configured via a header include rule).
-func bodyExtractionContentTypeHeader(t *testing.T) {
+func bodyExtractionContentTypeHeader(t *testing.T, postOperation string) {
 	for i := 0; i < 4; i++ {
 		doHTTPPost(t, instrumentedServiceStdURL+"/rolldice/53", 200,
 			[]byte(`{"test":"header-check"}`))
@@ -159,7 +166,7 @@ func bodyExtractionContentTypeHeader(t *testing.T) {
 
 	var trace jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=POST%20%2Frolldice%2F%3Aid")
+		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=" + url.QueryEscape(postOperation))
 		require.NoError(ct, err)
 		if resp == nil {
 			return
@@ -173,7 +180,7 @@ func bodyExtractionContentTypeHeader(t *testing.T) {
 		trace = traces[0]
 	}, testTimeout, 100*time.Millisecond)
 
-	res := trace.FindByOperationName("POST /rolldice/:id", "server")
+	res := trace.FindByOperationName(postOperation, "server")
 	require.NotEmpty(t, res)
 	span := res[0]
 
@@ -201,10 +208,10 @@ func TestSuiteBodyExtraction(t *testing.T) {
 
 	t.Run("Body extraction obfuscate", func(t *testing.T) {
 		waitForTestComponents(t, instrumentedServiceStdURL)
-		bodyExtractionObfuscate(t)
+		bodyExtractionObfuscate(t, "POST /rolldice/:id")
 	})
 	t.Run("Body extraction include", func(t *testing.T) {
-		bodyExtractionInclude(t)
+		bodyExtractionInclude(t, "POST /rolldice/:id")
 	})
 	t.Run("Body excluded by default", func(t *testing.T) {
 		// The socket tracer doesn't capture the Go mux pattern, so OBI resolves
@@ -212,7 +219,7 @@ func TestSuiteBodyExtraction(t *testing.T) {
 		bodyExtractionExcludedByDefault(t, "GET /rolldice/:id")
 	})
 	t.Run("Body with Content-Type header", func(t *testing.T) {
-		bodyExtractionContentTypeHeader(t)
+		bodyExtractionContentTypeHeader(t, "POST /rolldice/:id")
 	})
 
 	runWeaverValidation(t)

--- a/internal/test/integration/http_go_enrichment_body_test.go
+++ b/internal/test/integration/http_go_enrichment_body_test.go
@@ -23,10 +23,10 @@ func TestSuiteGoBodyExtraction(t *testing.T) {
 
 	t.Run("Body extraction obfuscate", func(t *testing.T) {
 		waitForTestComponents(t, instrumentedServiceStdURL)
-		bodyExtractionObfuscate(t)
+		bodyExtractionObfuscate(t, "POST /rolldice/{id}")
 	})
 	t.Run("Body extraction include", func(t *testing.T) {
-		bodyExtractionInclude(t)
+		bodyExtractionInclude(t, "POST /rolldice/{id}")
 	})
 	t.Run("Body excluded by default", func(t *testing.T) {
 		// The Go uprobe tracer captures the native std-mux pattern, reported
@@ -34,7 +34,7 @@ func TestSuiteGoBodyExtraction(t *testing.T) {
 		bodyExtractionExcludedByDefault(t, "GET /rolldice/{id}")
 	})
 	t.Run("Body with Content-Type header", func(t *testing.T) {
-		bodyExtractionContentTypeHeader(t)
+		bodyExtractionContentTypeHeader(t, "POST /rolldice/{id}")
 	})
 
 	require.NoError(t, compose.Close())

--- a/internal/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/internal/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -103,21 +103,21 @@ func FeatureHTTPMetricsDecoration(manifest string, overrideAttrs map[string]stri
 	}
 
 	allAttributes := map[string]string{
-		"k8s_namespace_name":       "^default$",
-		"k8s_node_name":            ".+-control-plane$",
-		"k8s_pod_uid":              UUIDRegex,
-		"k8s_pod_start_time":       TimeRegex,
-		"k8s_owner_name":           "^testserver$",
-		"k8s_deployment_name":      "^testserver$",
-		"k8s_replicaset_name":      "^testserver-",
-		"k8s_cluster_name":         "^obi-k8s-test-cluster$",
-		"server_service_namespace": "integration-test",
-		"server":                   "testserver",
-		"source":                   "obi",
-		"host_name":                "testserver",
-		"host_id":                  HostIDRegex,
-		"deployment_environment":   "integration-test",
-		"service_version":          "3.2.1",
+		"k8s_namespace_name":          "^default$",
+		"k8s_node_name":               ".+-control-plane$",
+		"k8s_pod_uid":                 UUIDRegex,
+		"k8s_pod_start_time":          TimeRegex,
+		"k8s_owner_name":              "^testserver$",
+		"k8s_deployment_name":         "^testserver$",
+		"k8s_replicaset_name":         "^testserver-",
+		"k8s_cluster_name":            "^obi-k8s-test-cluster$",
+		"server_service_namespace":    "integration-test",
+		"server":                      "testserver",
+		"source":                      "obi",
+		"host_name":                   "testserver",
+		"host_id":                     HostIDRegex,
+		"deployment_environment_name": "test",
+		"service_version":             "3.2.1",
 	}
 	// if service_instance_id is overridden to be empty, we will check that value for target_info{instance} instead
 	if overrideAttrs != nil {
@@ -232,17 +232,17 @@ func FeatureGRPCMetricsDecoration(manifest string, overrideAttrs map[string]stri
 	}
 
 	allAttributes := map[string]string{
-		"k8s_namespace_name":     "^default$",
-		"k8s_node_name":          ".+-control-plane$",
-		"k8s_pod_uid":            UUIDRegex,
-		"k8s_pod_start_time":     TimeRegex,
-		"k8s_cluster_name":       "^obi-k8s-test-cluster",
-		"k8s_owner_name":         "^testserver$",
-		"k8s_deployment_name":    "^testserver$",
-		"k8s_replicaset_name":    "^testserver-",
-		"service_instance_id":    "^default\\.testserver-.+\\.testserver",
-		"deployment_environment": "integration-test",
-		"service_version":        "3.2.1",
+		"k8s_namespace_name":          "^default$",
+		"k8s_node_name":               ".+-control-plane$",
+		"k8s_pod_uid":                 UUIDRegex,
+		"k8s_pod_start_time":          TimeRegex,
+		"k8s_cluster_name":            "^obi-k8s-test-cluster",
+		"k8s_owner_name":              "^testserver$",
+		"k8s_deployment_name":         "^testserver$",
+		"k8s_replicaset_name":         "^testserver-",
+		"service_instance_id":         "^default\\.testserver-.+\\.testserver",
+		"deployment_environment_name": "test",
+		"service_version":             "3.2.1",
 	}
 	// if service_instance_id is overridden to be empty, we will check that value for target_info{instance} instead
 	targetInfoInstance := ""
@@ -262,10 +262,10 @@ func FeatureGRPCMetricsDecoration(manifest string, overrideAttrs map[string]stri
 				attributeMap(allAttributes, overrideAttrs))).
 		Assess("target_info metrics exist",
 			testMetricsDecoration([]string{"target_info"}, `{job=~".*testserver"}`, map[string]string{
-				"host_name":              "testserver",
-				"host_id":                HostIDRegex,
-				"instance":               targetInfoInstance,
-				"deployment_environment": "integration-test",
+				"host_name":                   "testserver",
+				"host_id":                     HostIDRegex,
+				"instance":                    targetInfoInstance,
+				"deployment_environment_name": "test",
 			}),
 		).Feature()
 }

--- a/internal/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
+++ b/internal/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
@@ -51,10 +51,14 @@ func TestMain(m *testing.M) {
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod, validated at suite
+		// teardown (enforcing)
+		kube.WeaverValidation(kube.WeaverRequireSpans()),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver.yml"),
 		kube.Deploy(testpath.Manifests+"/04-jaeger.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
 		kube.Deploy(testpath.Manifests+"/06-obi-daemonset.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver.yml"),
 	)
 
 	cluster.Run(m)

--- a/internal/test/integration/k8s/daemonset_multi_node/k8s_daemonset_multi_node_main_test.go
+++ b/internal/test/integration/k8s/daemonset_multi_node/k8s_daemonset_multi_node_main_test.go
@@ -49,10 +49,14 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("obi:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol-multi-node.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod (both pinned to the
+		// `otel` zone node), validated at suite teardown (enforcing)
+		kube.WeaverValidation(kube.WeaverRequireSpans()),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver-multi-node.yml"),
 		kube.Deploy(testpath.Manifests+"/04-jaeger-multi-node.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-few-services.yml"),
 		kube.Deploy(testpath.Manifests+"/06-obi-daemonset-multi-node.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver-multi-node.yml"),
 	)
 
 	cluster.Run(m)

--- a/internal/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
+++ b/internal/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
@@ -47,10 +47,14 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("obi:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod, validated at suite
+		// teardown (enforcing)
+		kube.WeaverValidation(kube.WeaverRequireSpans()),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver.yml"),
 		kube.Deploy(testpath.Manifests+"/04-jaeger.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service-python.yml"),
 		kube.Deploy(testpath.Manifests+"/06-obi-daemonset-python.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver.yml"),
 	)
 
 	cluster.Run(m)

--- a/internal/test/integration/k8s/disable_informers/k8s_disable_informers_test.go
+++ b/internal/test/integration/k8s/disable_informers/k8s_disable_informers_test.go
@@ -43,10 +43,14 @@ func TestMain(m *testing.M) {
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod, validated at suite
+		// teardown (enforcing)
+		kube.WeaverValidation(),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver.yml"),
 		kube.Deploy(testpath.Manifests+"/04-jaeger.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
 		kube.Deploy(testpath.Manifests+"/06-obi-daemonset-disable-informers.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver.yml"),
 	)
 
 	cluster.Run(m)

--- a/internal/test/integration/k8s/manifests/00-kind-multi-node.yml
+++ b/internal/test/integration/k8s/manifests/00-kind-multi-node.yml
@@ -48,7 +48,7 @@ nodes:
         kind: JoinConfiguration
         nodeRegistration:
           kubeletExtraArgs:
-            node-labels: "deployment/zone=otel"  
+            node-labels: "deployment/zone=otel"
     extraMounts:
       # configuration files that need to be mounted in the host
       - hostPath: ../../configs
@@ -56,6 +56,10 @@ nodes:
       # testoutput folder to store coverage data
       - hostPath: ../../../../../testoutput
         containerPath: /testoutput
+      # OBI semconv registry, mounted read-only into the weaver pod (which is
+      # pinned to this `otel` zone node via nodeAffinity in 08-weaver-multi-node.yml)
+      - hostPath: ../../../../../schemas/obi
+        containerPath: /obi-registry
     extraPortMappings:
       # to avoid having to do port-forwarding from the Go client (a bit cumbersome process),
       # we just make visible some container ports through host ports
@@ -68,6 +72,15 @@ nodes:
         hostPort: 39090
       - containerPort: 16686
         hostPort: 36686
+      # weaver admin port (POST /stop from the test host)
+      - containerPort: 4320
+        hostPort: 32320
+      # weavercol telemetry (dropped-export check at teardown)
+      - containerPort: 8888
+        hostPort: 32888
+      # suite otelcol telemetry (first-hop dropped-export check)
+      - containerPort: 8890
+        hostPort: 32889
   - role: control-plane
     labels:
       cluster.x-k8s.io/cluster-name: obi-k8s-test-cluster

--- a/internal/test/integration/k8s/manifests/00-kind-multi-zone.yml
+++ b/internal/test/integration/k8s/manifests/00-kind-multi-zone.yml
@@ -40,6 +40,10 @@ nodes:
       # testoutput folder to store coverage data
       - hostPath: ../../../../../testoutput
         containerPath: /testoutput
+      # OBI semconv registry, mounted read-only into the weaver pod (pinned to
+      # this `otel` zone node via nodeAffinity in 08-weaver-multi-node.yml)
+      - hostPath: ../../../../../schemas/obi
+        containerPath: /obi-registry
     extraPortMappings:
       # to avoid having to do port-forwarding from the Go client (a bit cumbersome process),
       # we just make visible some container ports through host ports
@@ -50,3 +54,12 @@ nodes:
         hostPort: 38999
       - containerPort: 9090
         hostPort: 39090
+      # weaver admin port (POST /stop from the test host)
+      - containerPort: 4320
+        hostPort: 32320
+      # weavercol telemetry (dropped-export check at teardown)
+      - containerPort: 8888
+        hostPort: 32888
+      # suite otelcol telemetry (first-hop dropped-export check)
+      - containerPort: 8890
+        hostPort: 32889

--- a/internal/test/integration/k8s/manifests/00-kind.yml
+++ b/internal/test/integration/k8s/manifests/00-kind.yml
@@ -12,7 +12,21 @@ nodes:
       # testoutput folder to store coverage data
       - hostPath: ../../../../../testoutput
         containerPath: /testoutput
+      # OBI semconv registry, mounted read-only into the weaver pod
+      - hostPath: ../../../../../schemas/obi
+        containerPath: /obi-registry
     extraPortMappings:
+      # weaver admin port (POST /stop from the test host); container side is
+      # the pod hostPort 4320 (see 08-weaver.yml)
+      - containerPort: 4320
+        hostPort: 32320
+      # weavercol telemetry (dropped-export check at teardown); container side
+      # is the pod hostPort 8888 (see 08-weaver.yml)
+      - containerPort: 8888
+        hostPort: 32888
+      # suite otelcol telemetry (first-hop dropped-export check)
+      - containerPort: 8890
+        hostPort: 32889
       # to avoid having to do port-forwarding from the Go client (a bit cumbersome process),
       # we just make visible some container ports through host ports
       # hostPorts need to be in range 30000-32767

--- a/internal/test/integration/k8s/manifests/03-otelcol-weaver-multi-node.yml
+++ b/internal/test/integration/k8s/manifests/03-otelcol-weaver-multi-node.yml
@@ -1,0 +1,62 @@
+# otelcol with a weaver tap for multi-node / multi-zone weaver-wired suites.
+# Identical to 03-otelcol-multi-node.yml (pinned to the `otel` zone node) except
+# it runs otelcol-config-k8s-weaver.yml, which also fans metrics + traces out to
+# the in-cluster weaver pod over OTLP.
+apiVersion: v1
+kind: Service
+metadata:
+  name: otelcol
+spec:
+  selector:
+    app: otelcol
+  ports:
+    - port: 4317
+      name: otlp-grpc
+      targetPort: otlp-grpc
+    - port: 4318
+      name: otlp-http
+      targetPort: otlp-http
+    - port: 9464
+      name: prometheus
+      targetPort: prometheus
+    - port: 8888
+      name: metrics
+      targetPort: metrics
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: otelcol
+  labels:
+    app: otelcol
+spec:
+  volumes:
+    - name: configs
+      persistentVolumeClaim:
+        claimName: configs
+  affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: deployment/zone
+              operator: In
+              values:
+              - otel
+  containers:
+    - name: otelcol
+      image: otel/opentelemetry-collector-contrib:0.104.0
+      args: [ "--config=/etc/otelcol-config/otelcol-config-k8s-weaver.yml" ]
+      volumeMounts:
+        - mountPath: /etc/otelcol-config
+          name: configs
+      ports:
+        - containerPort: 4317
+          name: otlp-grpc
+        - containerPort: 4318
+          name: otlp-http
+        - containerPort: 9464
+          name: prometheus
+        - containerPort: 8888
+          name: metrics
+          hostPort: 8890

--- a/internal/test/integration/k8s/manifests/03-otelcol-weaver.yml
+++ b/internal/test/integration/k8s/manifests/03-otelcol-weaver.yml
@@ -1,0 +1,52 @@
+# otelcol with a weaver tap, for weaver-wired k8s suites. Identical to
+# 03-otelcol.yml except it runs otelcol-config-k8s-weaver.yml, which also
+# fans metrics + traces out to the in-cluster weaver pod over OTLP.
+apiVersion: v1
+kind: Service
+metadata:
+  name: otelcol
+spec:
+  selector:
+    app: otelcol
+  ports:
+    - port: 4317
+      name: otlp-grpc
+      targetPort: otlp-grpc
+    - port: 4318
+      name: otlp-http
+      targetPort: otlp-http
+    - port: 9464
+      name: prometheus
+      targetPort: prometheus
+    - port: 8888
+      name: metrics
+      targetPort: metrics
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: otelcol
+  labels:
+    app: otelcol
+spec:
+  volumes:
+    - name: configs
+      persistentVolumeClaim:
+        claimName: configs
+  containers:
+    - name: otelcol
+      image: otel/opentelemetry-collector-contrib:0.104.0
+      args: [ "--config=/etc/otelcol-config/otelcol-config-k8s-weaver.yml" ]
+      volumeMounts:
+        - mountPath: /etc/otelcol-config
+          name: configs
+      ports:
+        - containerPort: 4317
+          name: otlp-grpc
+        - containerPort: 4318
+          name: otlp-http
+        - containerPort: 9464
+          name: prometheus
+        - containerPort: 8888
+          name: metrics
+          hostPort: 8890

--- a/internal/test/integration/k8s/manifests/05-instrumented-service-otel.yml
+++ b/internal/test/integration/k8s/manifests/05-instrumented-service-otel.yml
@@ -75,7 +75,7 @@ spec:
             - name: LOG_LEVEL
               value: "DEBUG"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "deployment.environment=integration-test,service.version=3.2.1"
+              value: "deployment.environment.name=test,service.version=3.2.1"
         - name: obi
           image: obi:dev
           imagePullPolicy: Never # loaded into Kind from localhost
@@ -101,7 +101,7 @@ spec:
             - name: OTEL_EBPF_SERVICE_NAMESPACE
               value: "integration-test"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
             - name: OTEL_EBPF_LOG_LEVEL
@@ -116,3 +116,9 @@ spec:
               value: "application,application_span,application_service_graph"
             - name: OTEL_EBPF_NAME_RESOLVER_SOURCES
               value: "dns,k8s"
+            # Route traces through the weaver-tapped otelcol (which forwards
+            # them on to jaeger, so the jaeger-based trace assertions keep
+            # working) instead of straight at jaeger as obi-config.yml does, so
+            # weaver actually sees spans and can validate span semconv.
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: "http://otelcol:4318"

--- a/internal/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
+++ b/internal/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
@@ -88,7 +88,7 @@ spec:
             - name: LOG_LEVEL
               value: "DEBUG"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "deployment.environment=integration-test,service.version=3.2.1"
+              value: "deployment.environment.name=test,service.version=3.2.1"
         - name: obi
           image: obi:dev
           imagePullPolicy: Never # loaded into Kind from localhost
@@ -113,7 +113,7 @@ spec:
             - name: OTEL_EBPF_SERVICE_NAMESPACE
               value: "integration-test"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
             - name: OTEL_EBPF_LOG_LEVEL

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-cronjob.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-cronjob.yml
@@ -27,7 +27,7 @@ spec:
           labels:
             app: cronjobservice
           annotations:
-            resource.opentelemetry.io/deployment.environment: 'integration-test'
+            resource.opentelemetry.io/deployment.environment.name: 'test'
             resource.opentelemetry.io/service.version: '3.2.1'
         spec:
           restartPolicy: Never

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-daemonset.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-daemonset.yml
@@ -26,7 +26,7 @@ spec:
       labels:
         app: dsservice
       annotations:
-        resource.opentelemetry.io/deployment.environment: 'integration-test'
+        resource.opentelemetry.io/deployment.environment.name: 'test'
         resource.opentelemetry.io/service.version: '3.2.1'
     spec:
       containers:

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-few-services.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-few-services.yml
@@ -54,9 +54,9 @@ spec:
       name: pytestserver
       labels:
         app: pytestserver
-        deployment.environment: 'to-be-ignored-in-favor-of-annotation'
+        deployment.environment.name: 'to-be-ignored-in-favor-of-annotation'
       annotations:
-        resource.opentelemetry.io/deployment.environment: 'integration-test'
+        resource.opentelemetry.io/deployment.environment.name: 'test'
     spec:
       affinity:
           nodeAffinity:

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-job.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-job.yml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: jobservice
       annotations:
-        resource.opentelemetry.io/deployment.environment: 'integration-test'
+        resource.opentelemetry.io/deployment.environment.name: 'test'
         resource.opentelemetry.io/service.version: '3.2.1'
     spec:
       restartPolicy: Never

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-multizone-client-server.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-multizone-client-server.yml
@@ -12,7 +12,7 @@ metadata:
     # kind, to force OBI writing the coverage data
     teardown: delete
   annotations:
-    resource.opentelemetry.io/deployment.environment: integration-test
+    resource.opentelemetry.io/deployment.environment.name: test
     resource.opentelemetry.io/service.version: '3.2.1'
 spec:
   affinity:
@@ -64,7 +64,7 @@ spec:
         # kind, to force OBI writing the coverage data
         teardown: delete
       annotations:
-        resource.opentelemetry.io/deployment.environment: integration-test
+        resource.opentelemetry.io/deployment.environment.name: test
         resource.opentelemetry.io/service.version: '3.2.1'
     spec:
       affinity:

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-server-client-different-nodes.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-server-client-different-nodes.yml
@@ -37,7 +37,7 @@ spec:
         - name: TARGET_URL
           value: "http://otherinstance:8080"
         - name: OTEL_RESOURCE_ATTRIBUTES
-          value: "deployment.environment=integration-test,service.version=3.2.1"
+          value: "deployment.environment.name=test,service.version=3.2.1"
 ---
 apiVersion: v1
 kind: Service
@@ -112,4 +112,4 @@ spec:
             - name: LOG_LEVEL
               value: "DEBUG"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "deployment.environment=integration-test,service.version=3.2.1"
+              value: "deployment.environment.name=test,service.version=3.2.1"

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-service-python.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-service-python.yml
@@ -26,10 +26,10 @@ spec:
       name: pytestserver
       labels:
         app: pytestserver
-        deployment.environment: 'to-be-ignored-in-favor-of-annotatoin'
+        deployment.environment.name: 'to-be-ignored-in-favor-of-annotation'
       annotations:
         resource.opentelemetry.io/service.name: 'this-will-be-ignored-due-to-otel-attrs-env'
-        resource.opentelemetry.io/deployment.environment: 'integration-test'
+        resource.opentelemetry.io/deployment.environment.name: 'test'
         resource.opentelemetry.io/service.version: '3.2.1'
     spec:
       containers:

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-service.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-service.yml
@@ -65,7 +65,7 @@ spec:
             - name: LOG_LEVEL
               value: "DEBUG"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "deployment.environment=integration-test"
+              value: "deployment.environment.name=test"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -84,7 +84,7 @@ spec:
       labels:
         app: otherinstance
       annotations:
-        resource.opentelemetry.io/deployment.environment: 'to-be-ignored-in-favor-of-env-var'
+        resource.opentelemetry.io/deployment.environment.name: 'to-be-ignored-in-favor-of-env-var'
     spec:
       containers:
         - name: otherinstance
@@ -98,4 +98,4 @@ spec:
             - name: LOG_LEVEL
               value: "DEBUG"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "deployment.environment=integration-test"
+              value: "deployment.environment.name=test"

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-statefulset.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-statefulset.yml
@@ -27,7 +27,7 @@ spec:
       labels:
         app: statefulservice
       annotations:
-        resource.opentelemetry.io/deployment.environment: 'integration-test'
+        resource.opentelemetry.io/deployment.environment.name: 'test'
         resource.opentelemetry.io/service.version: '3.2.1'
     spec:
       containers:

--- a/internal/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
+++ b/internal/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
@@ -22,7 +22,7 @@ metadata:
     # kind, to force OBI writing the coverage data
     teardown: delete
   annotations:
-    resource.opentelemetry.io/deployment.environment: 'integration-test'
+    resource.opentelemetry.io/deployment.environment.name: 'test'
     resource.opentelemetry.io/service.version: '3.2.1'
 spec:
   shareProcessNamespace: true
@@ -66,7 +66,7 @@ spec:
         - name: OTEL_EBPF_AUTO_TARGET_EXE
           value: "*httppinger"
         - name: OTEL_EBPF_METRICS_INTERVAL
-          value: "10ms"
+          value: "1s"
         - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
           value: "10ms"
         - name: OTEL_EBPF_LOG_LEVEL

--- a/internal/test/integration/k8s/manifests/06-instrumented-client.template.yml
+++ b/internal/test/integration/k8s/manifests/06-instrumented-client.template.yml
@@ -22,7 +22,7 @@ metadata:
     # kind, to force OBI writing the coverage data
     teardown: delete
   annotations:
-    resource.opentelemetry.io/deployment.environment: 'integration-test'
+    resource.opentelemetry.io/deployment.environment.name: 'test'
     resource.opentelemetry.io/service.version: '3.2.1'
 spec:
   shareProcessNamespace: true
@@ -66,7 +66,7 @@ spec:
         - name: OTEL_EBPF_EXECUTABLE_PATH
           value: "httppinger"
         - name: OTEL_EBPF_METRICS_INTERVAL
-          value: "10ms"
+          value: "1s"
         - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
           value: "10ms"
         - name: OTEL_EBPF_LOG_LEVEL

--- a/internal/test/integration/k8s/manifests/06-instrumented-grpc-client-prom.template.yml
+++ b/internal/test/integration/k8s/manifests/06-instrumented-grpc-client-prom.template.yml
@@ -23,7 +23,7 @@ metadata:
     # kind, to force OBI writing the coverage data
     teardown: delete
   annotations:
-    resource.opentelemetry.io/deployment.environment: 'integration-test'
+    resource.opentelemetry.io/deployment.environment.name: 'test'
     resource.opentelemetry.io/service.version: '3.2.1'
 spec:
   shareProcessNamespace: true
@@ -67,7 +67,7 @@ spec:
         - name: OTEL_GO_AUTO_TARGET_EXE
           value: "*grpcpinger"
         - name: OTEL_EBPF_METRICS_INTERVAL
-          value: "10ms"
+          value: "1s"
         - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
           value: "10ms"
         - name: OTEL_EBPF_LOG_LEVEL

--- a/internal/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
+++ b/internal/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
@@ -22,10 +22,10 @@ metadata:
     # this label will trigger a deletion of OBI pods before tearing down
     # kind, to force OBI writing the coverage data
     teardown: delete
-    deployment.environment: integration-test
+    deployment.environment.name: to-be-ignored-in-favor-of-annotation
     app.kubernetes.io/version: '3.2.1'
   annotations:
-    resource.opentelemetry.io/deployment.environment: 'to-be-ignored-in-favor-of-annotation'
+    resource.opentelemetry.io/deployment.environment.name: 'test'
 spec:
   shareProcessNamespace: true
   serviceAccountName: obi
@@ -68,7 +68,7 @@ spec:
         - name: OTEL_EBPF_EXECUTABLE_PATH
           value: "grpcpinger"
         - name: OTEL_EBPF_METRICS_INTERVAL
-          value: "10ms"
+          value: "1s"
         - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
           value: "10ms"
         - name: OTEL_EBPF_LOG_LEVEL

--- a/internal/test/integration/k8s/manifests/06-obi-daemonset-disable-informers.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-daemonset-disable-informers.yml
@@ -12,7 +12,7 @@ data:
           - node
           - service
         resource_labels:
-          deployment.environment: ["deployment.environment"]
+          deployment.environment.name: ["deployment.environment.name"]
       select:
         "*":
           include: ["*"]
@@ -77,7 +77,7 @@ spec:
             - name: OTEL_EBPF_DISCOVERY_POLL_INTERVAL
               value: "500ms"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
             - name: OTEL_EBPF_METRICS_TTL

--- a/internal/test/integration/k8s/manifests/06-obi-daemonset-multi-node.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-daemonset-multi-node.yml
@@ -8,7 +8,7 @@ data:
       kubernetes:
         enable: true
         resource_labels:
-          deployment.environment: ["deployment.environment"]
+          deployment.environment.name: ["deployment.environment.name"]
     trace_printer: text
     log_level: debug
     discovery:
@@ -79,7 +79,9 @@ spec:
             - name: OTEL_EBPF_DISCOVERY_POLL_INTERVAL
               value: "500ms"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: "http://otelcol:4318"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
             - name: OTEL_EBPF_NAME_RESOLVER_SOURCES

--- a/internal/test/integration/k8s/manifests/06-obi-daemonset-python.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-daemonset-python.yml
@@ -8,7 +8,7 @@ data:
       kubernetes:
         enable: true
         resource_labels:
-          deployment.environment: ["deployment.environment"]
+          deployment.environment.name: ["deployment.environment.name"]
     trace_printer: text
     log_level: debug
     discovery:
@@ -66,7 +66,9 @@ spec:
             - name: OTEL_EBPF_DISCOVERY_POLL_INTERVAL
               value: "500ms"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: "http://otelcol:4318"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
             - name: OTEL_EBPF_NAME_RESOLVER_SOURCES

--- a/internal/test/integration/k8s/manifests/06-obi-daemonset-sharedpidns.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-daemonset-sharedpidns.yml
@@ -16,8 +16,11 @@ data:
       patterns:
         - /pingpong
       unmatched: path
+    # Traces go through the weaver-tapped otelcol (which forwards them to
+    # jaeger, keeping the jaeger-based assertions working) so weaver can
+    # validate them — OBI exports nothing else in this suite.
     otel_traces_export:
-      endpoint: http://jaeger:4318
+      endpoint: http://otelcol:4318
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -61,7 +64,7 @@ spec:
             - name: OTEL_EBPF_DISCOVERY_POLL_INTERVAL
               value: "500ms"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
             - name: OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT

--- a/internal/test/integration/k8s/manifests/06-obi-daemonset.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-daemonset.yml
@@ -8,7 +8,7 @@ data:
       kubernetes:
         enable: true
         resource_labels:
-          deployment.environment: ["deployment.environment"]
+          deployment.environment.name: ["deployment.environment.name"]
     log_level: debug
     discovery:
       instrument:
@@ -79,7 +79,9 @@ spec:
             - name: OTEL_EBPF_DISCOVERY_POLL_INTERVAL
               value: "500ms"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: "http://otelcol:4318"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
             - name: OTEL_EBPF_METRICS_TTL

--- a/internal/test/integration/k8s/manifests/06-obi-external-informer.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-external-informer.yml
@@ -17,7 +17,7 @@ data:
         cluster_name: my-kube
         meta_cache_address: k8s-cache:50055
         resource_labels:
-          deployment.environment: ["${DEPLOYMENT_ENVIRONMENT:-deployment.environment}"]
+          deployment.environment.name: ["${DEPLOYMENT_ENVIRONMENT:-deployment.environment.name}"]
       select:
         "*":
           include: [ "*" ]
@@ -87,7 +87,7 @@ spec:
             - name: OTEL_EBPF_DISCOVERY_POLL_INTERVAL
               value: "500ms"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
           ports:

--- a/internal/test/integration/k8s/manifests/06-obi-netolly-dropexternal.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-netolly-dropexternal.yml
@@ -9,7 +9,7 @@ data:
         enable: true
         drop_external: true
         resource_labels:
-          deployment.environment: ["${DEPLOYMENT_ENVIRONMENT:-error-not-replaced}"]
+          deployment.environment.name: ["${DEPLOYMENT_ENVIRONMENT:-error-not-replaced}"]
       select:
         obi.network.flow.bytes:
           include:
@@ -72,11 +72,11 @@ spec:
             - name: OTEL_EBPF_NETWORK_CACHE_MAX_FLOWS
               value: "20"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
             - name: OTEL_EBPF_KUBE_CLUSTER_NAME
               value: "obi"
             # expecting to be replaced during the configuration YAML load
             - name: DEPLOYMENT_ENVIRONMENT
-              value: "deployment.environment"
+              value: "deployment.environment.name"

--- a/internal/test/integration/k8s/manifests/06-obi-netolly-multizone.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-netolly-multizone.yml
@@ -24,7 +24,7 @@ data:
         enable: true
         cluster_name: my-kube
         resource_labels:
-          deployment.environment: ["${DEPLOYMENT_ENVIRONMENT:-error-not-replaced}"]
+          deployment.environment.name: ["${DEPLOYMENT_ENVIRONMENT:-error-not-replaced}"]
       select:
         obi.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
@@ -82,13 +82,13 @@ spec:
             - name: OTEL_EBPF_NETWORK_CACHE_MAX_FLOWS
               value: "20"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
             - name: OTEL_METRIC_EXPORT_INTERVAL
               value: "5000"
             # expecting to be replaced during the configuration YAML load
             - name: DEPLOYMENT_ENVIRONMENT
-              value: "deployment.environment"
+              value: "deployment.environment.name"
             - name: OTEL_EBPF_NETWORK_MAX_FLOW_DURATION
               value: "1s"

--- a/internal/test/integration/k8s/manifests/06-obi-netolly-promexport.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-netolly-promexport.yml
@@ -22,7 +22,7 @@ data:
         enable: true
         cluster_name: my-kube
         resource_labels:
-          deployment.environment: ["deployment.environment"]
+          deployment.environment.name: ["deployment.environment.name"]
       select:
         obi.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
@@ -93,6 +93,6 @@ spec:
             - name: OTEL_EBPF_NETWORK_CACHE_MAX_FLOWS
               value: "20"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"

--- a/internal/test/integration/k8s/manifests/06-obi-netolly-tc-promexport.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-netolly-tc-promexport.yml
@@ -22,7 +22,7 @@ data:
         enable: true
         cluster_name: my-kube
         resource_labels:
-          deployment.environment: ["deployment.environment"]
+          deployment.environment.name: ["deployment.environment.name"]
       select:
         obi.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
@@ -98,6 +98,6 @@ spec:
             - name: OTEL_EBPF_NETWORK_CACHE_MAX_FLOWS
               value: "20"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"

--- a/internal/test/integration/k8s/manifests/06-obi-netolly.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-netolly.yml
@@ -22,7 +22,7 @@ data:
         enable: true
         cluster_name: my-kube
         resource_labels:
-          deployment.environment: ["${DEPLOYMENT_ENVIRONMENT:-deployment.environment}"]
+          deployment.environment.name: ["${DEPLOYMENT_ENVIRONMENT:-deployment.environment.name}"]
       select:
         obi.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
@@ -80,7 +80,7 @@ spec:
             - name: OTEL_EBPF_NETWORK_CACHE_MAX_FLOWS
               value: "20"
             - name: OTEL_EBPF_METRICS_INTERVAL
-              value: "10ms"
+              value: "1s"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
             # in tests not running on multi-node Kind setups, this property

--- a/internal/test/integration/k8s/manifests/06-uninstrumented-client.template.yml
+++ b/internal/test/integration/k8s/manifests/06-uninstrumented-client.template.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     component: pinger
   annotations:
-    resource.opentelemetry.io/deployment.environment: 'to-be-ignored-in-favor-of-env-var'
+    resource.opentelemetry.io/deployment.environment.name: 'to-be-ignored-in-favor-of-env-var'
 spec:
   shareProcessNamespace: true
   serviceAccountName: obi
@@ -23,4 +23,4 @@ spec:
         - name: TARGET_URL
           value: "{{.TargetURL}}"
         - name: OTEL_RESOURCE_ATTRIBUTES
-          value: "deployment.environment=integration-test,service.version=3.2.1"
+          value: "deployment.environment.name=test,service.version=3.2.1"

--- a/internal/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
+++ b/internal/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
@@ -63,10 +63,10 @@ metadata:
     # this label will trigger a deletion of OBI pods before tearing down
     # kind, to force OBI writing the coverage data
     teardown: delete
-    deployment.environment: integration-test
+    deployment.environment.name: test
     app.kubernetes.io/service.version: 3.2.1
   annotations:
-    resource.opentelemetry.io/deployment.environment: 'to-be-ignored-in-favor-of-env'
+    resource.opentelemetry.io/deployment.environment.name: 'to-be-ignored-in-favor-of-env'
 spec:
   shareProcessNamespace: true
   serviceAccountName: obi
@@ -119,7 +119,7 @@ spec:
         - name: OTEL_EBPF_SERVICE_NAMESPACE
           value: "integration-test"
         - name: OTEL_EBPF_METRICS_INTERVAL
-          value: "10ms"
+          value: "1s"
         - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
           value: "10ms"
         - name: OTEL_EBPF_LOG_LEVEL

--- a/internal/test/integration/k8s/manifests/08-weaver-multi-node.yml
+++ b/internal/test/integration/k8s/manifests/08-weaver-multi-node.yml
@@ -1,0 +1,158 @@
+# Weaver pod for multi-node / multi-zone weaver-wired suites. Identical to
+# 08-weaver.yml but pinned (nodeAffinity) to the `otel` zone node, which is the
+# node whose 00-kind*.yml entry carries the /obi-registry extraMount and the
+# 4320 -> 32320 admin port mapping.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: obi-registry
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadOnlyMany
+  capacity:
+    storage: 10Mi
+  hostPath:
+    # Value set by the `obi-registry` extraMount in 00-kind*.yml
+    path: /obi-registry
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: obi-registry
+spec:
+  volumeName: obi-registry
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 10Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: weaver
+spec:
+  selector:
+    app: weaver
+  ports:
+    - port: 4317
+      name: otlp-grpc
+      targetPort: otlp-grpc
+    - port: 4320
+      name: admin
+      targetPort: admin
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: weaver
+  labels:
+    app: weaver
+spec:
+  volumes:
+    - name: obi-registry
+      persistentVolumeClaim:
+        claimName: obi-registry
+  affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: deployment/zone
+              operator: In
+              values:
+              - otel
+  containers:
+    - name: weaver
+      # v0.25.1+ required: earlier live-check shuts its admin server down 60s
+      # after startup (weaver #1645), restarting weaver mid-suite and dropping
+      # the early span burst from the teardown report.
+      image: otel/weaver:v0.25.1@sha256:9ad46ca9cd4fa5974b121f886aa3e9946a8ef8ea905001a96c018d21f9db87ca
+      # Root, like the docker-compose weaver (user: "0:0").
+      securityContext:
+        runAsUser: 0
+      workingDir: /obi-registry
+      args:
+        - registry
+        - live-check
+        - --registry
+        - /obi-registry
+        - --include-unreferenced
+        - --inactivity-timeout
+        - "300"
+        - --admin-port
+        - "4320"
+        - --format
+        - compact
+        - --templates
+        - /obi-registry/.live_check_templates
+        - --diagnostic-format
+        - json
+        - --output
+        - http
+      volumeMounts:
+        - mountPath: /obi-registry
+          name: obi-registry
+          readOnly: true
+      ports:
+        - containerPort: 4317
+          name: otlp-grpc
+        - containerPort: 4320
+          name: admin
+          hostPort: 4320
+---
+# Intermediate collector decoupling the suite otelcol from weaver's slow
+# ingestion (see configs/otelcol-config-k8s-weavercol.yml for the rationale).
+# Runs a newer contrib image than the base 03-otelcol pin for the `interval`
+# processor and `sending_queue.block_on_overflow`; safe to diverge here since
+# nothing in the production assertion path depends on it.
+apiVersion: v1
+kind: Service
+metadata:
+  name: weavercol
+spec:
+  selector:
+    app: weavercol
+  ports:
+    - port: 4317
+      name: otlp-grpc
+      targetPort: otlp-grpc
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: weavercol
+  labels:
+    app: weavercol
+spec:
+  affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: deployment/zone
+              operator: In
+              values:
+              - otel
+  volumes:
+    - name: configs
+      persistentVolumeClaim:
+        claimName: configs
+  containers:
+    - name: weavercol
+      image: otel/opentelemetry-collector-contrib:0.155.0
+      args: [ "--config=/etc/otelcol-config/otelcol-config-k8s-weavercol.yml" ]
+      volumeMounts:
+        - mountPath: /etc/otelcol-config
+          name: configs
+      ports:
+        # weavercol's own telemetry, scraped from the host at teardown to
+        # detect exports dropped before weaver (exposed via the kind
+        # extraPortMapping 8888 -> WeaverColMetricsHostPort in 00-kind*.yml,
+        # on this same otel-zone node)
+        - containerPort: 8888
+          name: metrics
+          hostPort: 8888
+        - containerPort: 4317
+          name: otlp-grpc

--- a/internal/test/integration/k8s/manifests/08-weaver.yml
+++ b/internal/test/integration/k8s/manifests/08-weaver.yml
@@ -1,0 +1,148 @@
+# Weaver semantic-convention validator for the Kubernetes / kind suites.
+#
+# Receives OTLP (metrics + traces) from the otelcol weaver tap
+# (03-otelcol-weaver.yml + configs/otelcol-config-k8s-weaver.yml) and validates
+# the emitted telemetry against the OBI schema registry under `schemas/obi/`,
+# mounted read-only at /obi-registry via the kind `obi-registry` extraMount
+# (see 00-kind*.yml). It writes its live-check report to
+# /testoutput/weaver-out/live_check.json on the shared testoutput mount; the Go
+# harness reads it from the host after POSTing /stop to the admin port (4320),
+# which the kind config exposes on host port 32320.
+#
+# This is the in-cluster counterpart of components/weaver/service.yml.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: obi-registry
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadOnlyMany
+  capacity:
+    storage: 10Mi
+  hostPath:
+    # Value set by the `obi-registry` extraMount in 00-kind*.yml
+    path: /obi-registry
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: obi-registry
+spec:
+  volumeName: obi-registry
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 10Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: weaver
+spec:
+  selector:
+    app: weaver
+  ports:
+    - port: 4317
+      name: otlp-grpc
+      targetPort: otlp-grpc
+    - port: 4320
+      name: admin
+      targetPort: admin
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: weaver
+  labels:
+    app: weaver
+spec:
+  volumes:
+    - name: obi-registry
+      persistentVolumeClaim:
+        claimName: obi-registry
+  containers:
+    - name: weaver
+      # v0.25.1+ required: earlier live-check shuts its admin server down 60s
+      # after startup (weaver #1645), restarting weaver mid-suite and dropping
+      # the early span burst from the teardown report.
+      image: otel/weaver:v0.25.1@sha256:9ad46ca9cd4fa5974b121f886aa3e9946a8ef8ea905001a96c018d21f9db87ca
+      # Root, like the docker-compose weaver (user: "0:0").
+      securityContext:
+        runAsUser: 0
+      workingDir: /obi-registry
+      args:
+        - registry
+        - live-check
+        - --registry
+        - /obi-registry
+        - --include-unreferenced
+        - --inactivity-timeout
+        - "300"
+        - --admin-port
+        - "4320"
+        - --format
+        - compact
+        - --templates
+        - /obi-registry/.live_check_templates
+        - --diagnostic-format
+        - json
+        - --output
+        - http
+      volumeMounts:
+        - mountPath: /obi-registry
+          name: obi-registry
+          readOnly: true
+      ports:
+        - containerPort: 4317
+          name: otlp-grpc
+        - containerPort: 4320
+          name: admin
+          # exposed on the host via the kind extraPortMapping (host 32320)
+          hostPort: 4320
+---
+# Intermediate collector decoupling the suite otelcol from weaver's slow
+# ingestion (see configs/otelcol-config-k8s-weavercol.yml for the rationale).
+# Runs a newer contrib image than the base 03-otelcol pin for the `interval`
+# processor and `sending_queue.block_on_overflow`; safe to diverge here since
+# nothing in the production assertion path depends on it.
+apiVersion: v1
+kind: Service
+metadata:
+  name: weavercol
+spec:
+  selector:
+    app: weavercol
+  ports:
+    - port: 4317
+      name: otlp-grpc
+      targetPort: otlp-grpc
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: weavercol
+  labels:
+    app: weavercol
+spec:
+  volumes:
+    - name: configs
+      persistentVolumeClaim:
+        claimName: configs
+  containers:
+    - name: weavercol
+      image: otel/opentelemetry-collector-contrib:0.155.0
+      args: [ "--config=/etc/otelcol-config/otelcol-config-k8s-weavercol.yml" ]
+      volumeMounts:
+        - mountPath: /etc/otelcol-config
+          name: configs
+      ports:
+        - containerPort: 4317
+          name: otlp-grpc
+        # weavercol's own telemetry, scraped from the host at teardown to
+        # detect exports dropped before weaver (exposed via the kind
+        # extraPortMapping 8888 -> WeaverColMetricsHostPort in 00-kind*.yml)
+        - containerPort: 8888
+          name: metrics
+          hostPort: 8888

--- a/internal/test/integration/k8s/netolly/k8s_netolly_main_test.go
+++ b/internal/test/integration/k8s/netolly/k8s_netolly_main_test.go
@@ -43,9 +43,13 @@ func TestMain(m *testing.M) {
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod, validated at suite
+		// teardown (enforcing)
+		kube.WeaverValidation(),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
 		kube.Deploy(testpath.Manifests+"/06-obi-netolly.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver.yml"),
 	)
 
 	cluster.Run(m)

--- a/internal/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
+++ b/internal/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
@@ -56,9 +56,13 @@ func TestMain(m *testing.M) {
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod, validated at suite
+		// teardown (enforcing)
+		kube.WeaverValidation(),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
 		kube.Deploy(testpath.Manifests+"/06-obi-netolly-dropexternal.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver.yml"),
 	)
 
 	cluster.Run(m)

--- a/internal/test/integration/k8s/netolly_multizone/k8s_netolly_multizone_main_test.go
+++ b/internal/test/integration/k8s/netolly_multizone/k8s_netolly_multizone_main_test.go
@@ -43,9 +43,13 @@ func TestMain(m *testing.M) {
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape-multi-node.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol-multi-node.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod (both pinned to the
+		// `otel` zone node), validated at suite teardown (enforcing)
+		kube.WeaverValidation(),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver-multi-node.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-multizone-client-server.yml"),
 		kube.Deploy(testpath.Manifests+"/06-obi-netolly-multizone.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver-multi-node.yml"),
 	)
 
 	cluster.Run(m)

--- a/internal/test/integration/k8s/otel/k8s_main_test.go
+++ b/internal/test/integration/k8s/otel/k8s_main_test.go
@@ -54,9 +54,15 @@ func TestMain(m *testing.M) {
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod, validated at suite
+		// teardown (enforcing). RequireSpans: this suite routes OBI traces
+		// through the tap, so a metrics-only report means the trace path
+		// broke and span semconv went unchecked.
+		kube.WeaverValidation(kube.WeaverRequireSpans()),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver.yml"),
 		kube.Deploy(testpath.Manifests+"/04-jaeger.yml"),
 		kube.Deploy(testpath.Manifests+"/05-instrumented-service-otel.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver.yml"),
 	)
 
 	cluster.Run(m)

--- a/internal/test/integration/k8s/owners/k8s_owners_main_test.go
+++ b/internal/test/integration/k8s/owners/k8s_owners_main_test.go
@@ -51,13 +51,17 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("grpcpinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod, validated at suite
+		// teardown (enforcing)
+		kube.WeaverValidation(kube.WeaverRequireSpans()),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver.yml"),
 		kube.Deploy(testpath.Manifests+"/04-jaeger.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-statefulset.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-daemonset.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-job.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-cronjob.yml"),
 		kube.Deploy(testpath.Manifests+"/06-obi-daemonset.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver.yml"),
 	)
 
 	cluster.Run(m)

--- a/internal/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
+++ b/internal/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
@@ -52,7 +52,7 @@ func TestMain(m *testing.M) {
 		// weaver-tapped otelcol + in-cluster weaver pod, validated at suite
 		// teardown (enforcing)
 		kube.WeaverValidation(),
-		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver-multi-node.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-server-client-different-nodes.yml"),
 		kube.Deploy(testpath.Manifests+"/06-obi-netolly.yml"),
 		kube.Deploy(testpath.Manifests+"/08-weaver-multi-node.yml"),

--- a/internal/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
+++ b/internal/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
@@ -49,9 +49,13 @@ func TestMain(m *testing.M) {
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape-multi-node.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod, validated at suite
+		// teardown (enforcing)
+		kube.WeaverValidation(),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-server-client-different-nodes.yml"),
 		kube.Deploy(testpath.Manifests+"/06-obi-netolly.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver-multi-node.yml"),
 	)
 
 	cluster.Run(m)

--- a/internal/test/integration/k8s/sharedpidns/k8s_sharedpidns_main_test.go
+++ b/internal/test/integration/k8s/sharedpidns/k8s_sharedpidns_main_test.go
@@ -50,7 +50,12 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("obi:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod, validated at suite
+		// teardown (enforcing). RequireSpans: this suite exists to exercise
+		// trace context propagation and routes OBI traces through the tap, so
+		// a metrics-only report means the trace path broke.
+		kube.WeaverValidation(kube.WeaverRequireSpans()),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver.yml"),
 		kube.Deploy(testpath.Manifests+"/04-jaeger.yml"),
 		// Deploy a normal Deployment (no hostPID)
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
@@ -58,6 +63,7 @@ func TestMain(m *testing.M) {
 		kube.Deploy(testpath.Manifests+"/05-hostpid-daemonset.yml"),
 		// Deploy OBI configured to instrument both
 		kube.Deploy(testpath.Manifests+"/06-obi-daemonset-sharedpidns.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver.yml"),
 	)
 
 	cluster.Run(m)

--- a/pkg/internal/netolly/flow/transport/networktype.go
+++ b/pkg/internal/netolly/flow/transport/networktype.go
@@ -3,10 +3,6 @@
 
 package transport // import "go.opentelemetry.io/obi/pkg/internal/netolly/flow/transport"
 
-import (
-	"strconv"
-)
-
 // NetworkType value stores the L3 network protocol (IPv4, IPV6....)
 // Values are defined in IEEE 802: https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml
 type NetworkType uint16
@@ -14,6 +10,7 @@ type NetworkType uint16
 const (
 	IPv4 = NetworkType(0x800)
 	IPv6 = NetworkType(0x86DD)
+	ARP  = NetworkType(0x806)
 )
 
 // String representation of the Protocol enum
@@ -23,6 +20,8 @@ func (p NetworkType) String() string {
 		return "ipv4"
 	case IPv6:
 		return "ipv6"
+	case ARP:
+		return "arp"
 	}
-	return strconv.Itoa(int(p))
+	return "unknown"
 }

--- a/schemas/obi/groups/k8s.yaml
+++ b/schemas/obi/groups/k8s.yaml
@@ -1,0 +1,27 @@
+groups:
+  - id: registry.obi.k8s
+    type: attribute_group
+    display_name: OBI Kubernetes Decoration
+    brief: >
+      Kubernetes metadata OBI's k8s decorator (pkg/transform/k8s.go) attaches
+      to the resource attributes of every decorated signal, beyond the
+      upstream `k8s.*` semconv attributes (`k8s.pod.name`,
+      `k8s.namespace.name`, …) it also sets. Declared here because upstream
+      semconv has no equivalent for the "top-level owner" abstraction OBI
+      uses to name the workload independently of its kind.
+    attributes:
+      - id: k8s.owner.name
+        type: string
+        stability: development
+        brief: >
+          Name of the top-level Kubernetes owner (Deployment, StatefulSet,
+          DaemonSet, CronJob, …) of the Pod OBI decorated the signal with.
+        examples: ["frontend"]
+      - id: k8s.kind
+        type: string
+        stability: development
+        brief: >
+          Kind of the top-level Kubernetes owner of the decorated Pod
+          (falls back to the direct owner's kind when no top-level owner is
+          resolved). Deliberately never `Pod`, to bound label cardinality.
+        examples: ["Deployment", "StatefulSet"]

--- a/schemas/obi/groups/network.yaml
+++ b/schemas/obi/groups/network.yaml
@@ -182,3 +182,40 @@ groups:
       - ref: dst.zone
       - ref: src.name
       - ref: dst.name
+
+  # Overrides `network.type`: extends the upstream `ipv4`/`ipv6` enum with
+  # `arp`, which OBI reports for ARP frames — OBI observes raw L2 frames, a
+  # case the upstream network-layer enum has no member for. Other non-IP
+  # EtherTypes fall back to `unknown` (pkg/internal/netolly/flow/transport,
+  # NetworkType.String); that bug-marker value is deliberately NOT declared
+  # here, so weaver keeps flagging it if it ever appears.
+  #
+  # See ../README.md for the override mechanics (x.obi.* group id, full
+  # upstream member list, lint allowlist).
+  - id: x.obi.network
+    type: attribute_group
+    display_name: OBI Network Attribute Overrides
+    brief: >
+      OBI override of `network.type` extending the upstream enum with `arp`
+      for the ARP frames OBI observes at L2.
+    attributes:
+      - id: network.type
+        stability: stable
+        type:
+          members:
+            - id: ipv4
+              value: 'ipv4'
+              brief: "IPv4"
+              stability: stable
+            - id: ipv6
+              value: 'ipv6'
+              brief: "IPv6"
+              stability: stable
+            # --- OBI extension (not in upstream semconv v1.41) ---
+            - id: arp
+              value: 'arp'
+              brief: "ARP (Address Resolution Protocol) frame observed at L2."
+              stability: development
+        brief: '[OSI network layer](https://wikipedia.org/wiki/Network_layer) or non-OSI equivalent.'
+        note: The value SHOULD be normalized to lowercase.
+        examples: ['ipv4', 'ipv6']

--- a/schemas/obi/groups/network.yaml
+++ b/schemas/obi/groups/network.yaml
@@ -104,6 +104,83 @@ groups:
         brief: CIDR block matched against the destination IP.
         examples: ["10.0.0.0/8"]
 
+      # Kubernetes decoration of the source / destination flow endpoints,
+      # attached by netolly (pkg/internal/netolly/transform/k8s) when
+      # Kubernetes metadata is available and the corresponding keys are
+      # selected. These `k8s.src.*` / `k8s.dst.*` keys are an OBI/netolly
+      # convention: unlike the upstream single-workload `k8s.*` semconv
+      # attributes, a flow has two endpoints to describe.
+      - id: k8s.src.owner.name
+        type: string
+        stability: development
+        brief: Name of the top-level Kubernetes owner of the source workload.
+        examples: ["frontend"]
+      - id: k8s.src.owner.type
+        type: string
+        stability: development
+        brief: Kind of the top-level Kubernetes owner of the source workload.
+        examples: ["Deployment"]
+      - id: k8s.src.namespace
+        type: string
+        stability: development
+        brief: Kubernetes namespace of the source workload.
+        examples: ["integration-test"]
+      - id: k8s.src.name
+        type: string
+        stability: development
+        brief: Name of the source Kubernetes object (e.g. Pod name).
+        examples: ["frontend-7d9c-abcde"]
+      - id: k8s.src.type
+        type: string
+        stability: development
+        brief: Type of the source Kubernetes object.
+        examples: ["Pod"]
+      - id: k8s.src.node.ip
+        type: string
+        stability: development
+        brief: IP address of the node hosting the source workload.
+        examples: ["10.0.1.5"]
+      - id: k8s.src.node.name
+        type: string
+        stability: development
+        brief: Name of the node hosting the source workload.
+        examples: ["node-1"]
+      - id: k8s.dst.owner.name
+        type: string
+        stability: development
+        brief: Name of the top-level Kubernetes owner of the destination workload.
+        examples: ["users-api"]
+      - id: k8s.dst.owner.type
+        type: string
+        stability: development
+        brief: Kind of the top-level Kubernetes owner of the destination workload.
+        examples: ["Deployment"]
+      - id: k8s.dst.namespace
+        type: string
+        stability: development
+        brief: Kubernetes namespace of the destination workload.
+        examples: ["integration-test"]
+      - id: k8s.dst.name
+        type: string
+        stability: development
+        brief: Name of the destination Kubernetes object (e.g. Pod name).
+        examples: ["users-api-65b8-fghij"]
+      - id: k8s.dst.type
+        type: string
+        stability: development
+        brief: Type of the destination Kubernetes object.
+        examples: ["Pod"]
+      - id: k8s.dst.node.ip
+        type: string
+        stability: development
+        brief: IP address of the node hosting the destination workload.
+        examples: ["10.0.1.6"]
+      - id: k8s.dst.node.name
+        type: string
+        stability: development
+        brief: Name of the node hosting the destination workload.
+        examples: ["node-2"]
+
   - id: metric.obi_network_flow_bytes
     type: metric
     metric_name: obi.network.flow.bytes
@@ -133,6 +210,20 @@ groups:
       - ref: dst.zone
       - ref: src.cidr
       - ref: dst.cidr
+      - ref: k8s.src.owner.name
+      - ref: k8s.src.owner.type
+      - ref: k8s.src.namespace
+      - ref: k8s.src.name
+      - ref: k8s.src.type
+      - ref: k8s.src.node.ip
+      - ref: k8s.src.node.name
+      - ref: k8s.dst.owner.name
+      - ref: k8s.dst.owner.type
+      - ref: k8s.dst.namespace
+      - ref: k8s.dst.name
+      - ref: k8s.dst.type
+      - ref: k8s.dst.node.ip
+      - ref: k8s.dst.node.name
 
   - id: metric.obi_network_flow_packets
     type: metric
@@ -164,6 +255,20 @@ groups:
       - ref: dst.zone
       - ref: src.cidr
       - ref: dst.cidr
+      - ref: k8s.src.owner.name
+      - ref: k8s.src.owner.type
+      - ref: k8s.src.namespace
+      - ref: k8s.src.name
+      - ref: k8s.src.type
+      - ref: k8s.src.node.ip
+      - ref: k8s.src.node.name
+      - ref: k8s.dst.owner.name
+      - ref: k8s.dst.owner.type
+      - ref: k8s.dst.namespace
+      - ref: k8s.dst.name
+      - ref: k8s.dst.type
+      - ref: k8s.dst.node.ip
+      - ref: k8s.dst.node.name
 
   - id: metric.obi_network_inter_zone_bytes
     type: metric

--- a/schemas/obi/groups/service_graph.yaml
+++ b/schemas/obi/groups/service_graph.yaml
@@ -60,6 +60,31 @@ groups:
           `servicegraphconnector` when `service.namespace` is added to the
           connector's `dimensions` list.
         examples: ["integration-test"]
+      # Underscored Kubernetes peer labels OBI attaches to service-graph
+      # metrics when Kubernetes decoration is active, mirroring the older
+      # network-metrics naming. Distinct from the dotted
+      # `k8s.namespace.name` / `k8s.cluster.name` semconv attributes, which
+      # describe a single workload rather than the two peers of an edge.
+      - id: client_k8s_namespace_name
+        type: string
+        stability: development
+        brief: Kubernetes namespace of the client (request-initiating) peer.
+        examples: ["integration-test"]
+      - id: server_k8s_namespace_name
+        type: string
+        stability: development
+        brief: Kubernetes namespace of the server (request-receiving) peer.
+        examples: ["integration-test"]
+      - id: client_k8s_cluster_name
+        type: string
+        stability: development
+        brief: Kubernetes cluster name of the client (request-initiating) peer.
+        examples: ["my-cluster"]
+      - id: server_k8s_cluster_name
+        type: string
+        stability: development
+        brief: Kubernetes cluster name of the server (request-receiving) peer.
+        examples: ["my-cluster"]
 
   # Counter has no explicit OTLP unit set; mirror that here so live-check
   # doesn't complain "Unit should be '1', but found ''".
@@ -78,6 +103,10 @@ groups:
       - ref: client_service_namespace
       - ref: server_service_namespace
       - ref: source
+      - ref: client_k8s_namespace_name
+      - ref: server_k8s_namespace_name
+      - ref: client_k8s_cluster_name
+      - ref: server_k8s_cluster_name
 
   # Counter has no explicit OTLP unit set; mirror that here so live-check
   # doesn't complain "Unit should be '1', but found ''".
@@ -97,6 +126,10 @@ groups:
       - ref: client_service_namespace
       - ref: server_service_namespace
       - ref: source
+      - ref: client_k8s_namespace_name
+      - ref: server_k8s_namespace_name
+      - ref: client_k8s_cluster_name
+      - ref: server_k8s_cluster_name
 
   - id: metric.traces_service_graph_request_server
     type: metric
@@ -113,6 +146,10 @@ groups:
       - ref: client_service_namespace
       - ref: server_service_namespace
       - ref: source
+      - ref: client_k8s_namespace_name
+      - ref: server_k8s_namespace_name
+      - ref: client_k8s_cluster_name
+      - ref: server_k8s_cluster_name
 
   - id: metric.traces_service_graph_request_client
     type: metric
@@ -129,3 +166,7 @@ groups:
       - ref: client_service_namespace
       - ref: server_service_namespace
       - ref: source
+      - ref: client_k8s_namespace_name
+      - ref: server_k8s_namespace_name
+      - ref: client_k8s_cluster_name
+      - ref: server_k8s_cluster_name

--- a/scripts/generate-integration-matrix.sh
+++ b/scripts/generate-integration-matrix.sh
@@ -5,58 +5,112 @@
 # Generate standard test matrix with configurable partitions
 # Usage: ./scripts/generate-integration-matrix.sh [search_dir] [partitions] [test_pattern]
 
-set -e
+set -euo pipefail
+shopt -s lastpipe
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd -- "${BASH_SOURCE[0]%/*}" && pwd -P)"
 SEARCH_DIR="${1:-internal/test/integration}"
 PARTITIONS="${2:-5}"
 TEST_PATTERN="${3:-Test}"
-WEIGHTS_FILE="$SCRIPT_DIR/integration-test-weights.generated.json"
+WEIGHTS_FILE="${OBI_INTEGRATION_TEST_WEIGHTS_FILE:-$SCRIPT_DIR/integration-test-weights.generated.json}"
 
-FILES=$(find "$SEARCH_DIR" -maxdepth 1 -type f -name "*_test.go")
-if [ -z "$FILES" ]; then
-    echo "No test files found" >&2
+required_commands=(awk find grep sed sort tr)
+missing_commands=()
+for command_name in "${required_commands[@]}"; do
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        missing_commands+=("$command_name")
+    fi
+done
+if (( ${#missing_commands[@]} > 0 )); then
+    printf 'ERROR: missing required commands: %s\n' "${missing_commands[*]}" >&2
     exit 1
 fi
 
-# Extract test function names from the files and sort
-TEST_NAMES=$(grep -hE "^func $TEST_PATTERN" $FILES | sed 's/^func \([^(]*\).*/\1/' | sort -u)
-
-if [ -z "$TEST_NAMES" ]; then
-    echo "ERROR: No tests found in '$SEARCH_DIR'" >&2
+if [[ ! "$PARTITIONS" =~ ^[1-9][0-9]*$ ]]; then
+    printf "ERROR: partitions must be a positive integer, got '%s'\n" "$PARTITIONS" >&2
+    exit 1
+fi
+if [[ ! -d "$SEARCH_DIR" ]]; then
+    printf "ERROR: search directory not found: '%s'\n" "$SEARCH_DIR" >&2
+    exit 1
+fi
+if [[ "$TEST_PATTERN" == *$'\n'* || "$TEST_PATTERN" == *$'\r'* ]]; then
+    echo "ERROR: test pattern must not contain newline or carriage return" >&2
     exit 1
 fi
 
-TOTAL_TESTS=$(echo "$TEST_NAMES" | wc -l | tr -d " ")
+declare -a test_files=()
+if ! find "$SEARCH_DIR" -maxdepth 1 -type f -name "*_test.go" -print0 | LC_ALL=C sort -z | mapfile -d '' -t test_files; then
+    echo "ERROR: failed to discover test files" >&2
+    exit 1
+fi
+
+if (( ${#test_files[@]} == 0 )); then
+    echo "ERROR: No test files found" >&2
+    exit 1
+fi
+
+declare -a test_names=()
+if grep -hE "^func $TEST_PATTERN" "${test_files[@]}" \
+    | sed 's/^func \([^(]*\).*/\1/' \
+    | LC_ALL=C sort -u \
+    | mapfile -t test_names; then
+    :
+else
+    extraction_status=("${PIPESTATUS[@]}")
+    if (( extraction_status[0] == 1 && extraction_status[1] == 0 && extraction_status[2] == 0 && extraction_status[3] == 0 )); then
+        printf "ERROR: No tests matching '%s' found in '%s'\n" "$TEST_PATTERN" "$SEARCH_DIR" >&2
+    else
+        printf 'ERROR: failed to extract test names (grep=%d sed=%d sort=%d read=%d)\n' "${extraction_status[@]}" >&2
+    fi
+    exit 1
+fi
 
 # Look up weights and assign tests to shards using LPT (Longest Processing Time)
 # bin packing: sort tests by weight descending, assign each to the lightest shard.
-if [ -f "$WEIGHTS_FILE" ] && command -v jq >/dev/null 2>&1; then
-    DEFAULT_WEIGHT=$(jq -r '._default // 20' "$WEIGHTS_FILE")
+if [[ -f "$WEIGHTS_FILE" ]] && command -v jq >/dev/null 2>&1; then
+    if ! jq -e -s '
+        length == 1 and (.[0]
+        | type == "object"
+        and ((if has("_default") then ._default else 20 end) | type == "number" and . >= 0)
+        and ([to_entries[] | select(.key != "_default") | .value
+              | type == "number" and . >= 0] | all)
+        )
+    ' "$WEIGHTS_FILE" >/dev/null; then
+        printf "ERROR: invalid weights file '%s'; weights must be non-negative numbers\n" "$WEIGHTS_FILE" >&2
+        exit 1
+    fi
 
-    # Build "weight testname" pairs, sorted by weight descending then name
-    WEIGHTED_TESTS=$(echo "$TEST_NAMES" | while read -r name; do
-        w=$(jq -r --arg n "$name" '.[$n] // empty' "$WEIGHTS_FILE")
-        if [ -z "$w" ]; then
-            w=$DEFAULT_WEIGHT
+    default_weight="$(jq -r 'if has("_default") then ._default else 20 end' "$WEIGHTS_FILE")"
+    weighted_tests=""
+    for name in "${test_names[@]}"; do
+        weight="$(jq -r --arg name "$name" '.[$name] // empty' "$WEIGHTS_FILE")"
+        if [[ -z "$weight" ]]; then
+            weight="$default_weight"
         fi
-        echo "$w $name"
-    done | sort -k1,1 -rn -k2,2)
+        weighted_tests+="$weight $name"$'\n'
+    done
+    weighted_tests="$(printf '%s' "$weighted_tests" | LC_ALL=C sort -k1,1 -rg -k2,2)"
 
-    echo "Using weighted bin packing (weights from $WEIGHTS_FILE)" >&2
+    printf 'Using weighted bin packing (weights from %s)\n' "$WEIGHTS_FILE" >&2
 else
-    # Fallback: equal weights, alphabetical order
-    DEFAULT_WEIGHT=20
-    WEIGHTED_TESTS=$(echo "$TEST_NAMES" | while read -r name; do
-        echo "$DEFAULT_WEIGHT $name"
-    done)
+    default_weight=20
+    weighted_tests=""
+    for name in "${test_names[@]}"; do
+        weighted_tests+="$default_weight $name"$'\n'
+    done
+    weighted_tests="${weighted_tests%$'\n'}"
 
     echo "Warning: weights file not found or jq not available, using equal weights" >&2
 fi
 
-# LPT bin packing via awk: assign each test (sorted heaviest first) to the
-# shard with the smallest accumulated weight.
-SHARD_ASSIGNMENTS=$(echo "$WEIGHTED_TESTS" | awk -v partitions="$PARTITIONS" '
+# Assign each test to the shard with the smallest accumulated weight.
+shard_count="$PARTITIONS"
+test_count="${#test_names[@]}"
+if [[ ${#PARTITIONS} -gt ${#test_count} || (${#PARTITIONS} -eq ${#test_count} && "$PARTITIONS" > "$test_count") ]]; then
+    shard_count="${#test_names[@]}"
+fi
+shard_assignments="$(awk -v partitions="$shard_count" '
 BEGIN {
     for (i = 0; i < partitions; i++) {
         shard_weight[i] = 0
@@ -65,8 +119,6 @@ BEGIN {
 {
     weight = $1
     name = $2
-
-    # Find the shard with the smallest total weight
     min_shard = 0
     min_weight = shard_weight[0]
     for (i = 1; i < partitions; i++) {
@@ -75,7 +127,6 @@ BEGIN {
             min_shard = i
         }
     }
-
     shard_weight[min_shard] += weight
     print min_shard, weight, name
 }
@@ -83,29 +134,27 @@ END {
     for (i = 0; i < partitions; i++) {
         printf "Shard %d estimated weight: %ds\n", i, shard_weight[i] > "/dev/stderr"
     }
-}')
+}' <<< "$weighted_tests")"
 
-echo "Total tests matching '$TEST_PATTERN': $TOTAL_TESTS, Partitions: $PARTITIONS" >&2
+printf "Total tests matching '%s': %d, Partitions: %s\n" "$TEST_PATTERN" "${#test_names[@]}" "$PARTITIONS" >&2
 
-# Generate matrix JSON from shard assignments
-MATRIX_JSON='{"include":['
-FIRST_SHARD=true
-
-for SHARD in $(seq 0 $((PARTITIONS - 1))); do
-    SHARD_TESTS=$(echo "$SHARD_ASSIGNMENTS" | awk -v s="$SHARD" '$1 == s { print $3 }' | tr "\n" "|" | sed "s/|$//")
-
-    if [ -n "$SHARD_TESTS" ]; then
-        if [ "$FIRST_SHARD" = "false" ]; then
-            MATRIX_JSON+=","
-        fi
-        FIRST_SHARD=false
-
-        TEST_COUNT=$(echo "$SHARD_TESTS" | tr "|" "\n" | wc -l | tr -d " ")
-        MATRIX_JSON+="{\"id\":$SHARD,\"description\":\"shard-$SHARD ($TEST_COUNT tests)\",\"test_pattern\":\"$SHARD_TESTS\"}"
-
-        echo "Shard $SHARD: $TEST_COUNT tests: $SHARD_TESTS" >&2
+matrix_json='{"include":['
+first_shard=true
+for (( shard = 0; shard < shard_count; shard++ )); do
+    shard_tests="$(awk -v shard="$shard" '$1 == shard { print $3 }' <<< "$shard_assignments" | tr "\n" "|" | sed "s/|$//")"
+    if [[ -z "$shard_tests" ]]; then
+        continue
     fi
+
+    if [[ "$first_shard" == "false" ]]; then
+        matrix_json+=","
+    fi
+    first_shard=false
+
+    test_count="$(tr "|" "\n" <<< "$shard_tests" | awk 'END { print NR }')"
+    matrix_json+="{\"id\":$shard,\"description\":\"shard-$shard ($test_count tests)\",\"test_pattern\":\"$shard_tests\"}"
+    printf 'Shard %d: %d tests: %s\n' "$shard" "$test_count" "$shard_tests" >&2
 done
 
-MATRIX_JSON+=']}'
-echo "$MATRIX_JSON"
+matrix_json+=']}'
+printf '%s\n' "$matrix_json"

--- a/scripts/generate-integration-matrix_test.go
+++ b/scripts/generate-integration-matrix_test.go
@@ -1,0 +1,243 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package scripts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+type integrationMatrix struct {
+	Include []struct {
+		TestPattern string `json:"test_pattern"`
+	} `json:"include"`
+}
+
+func TestGenerateIntegrationMatrixIsCompleteUniqueAndDeterministic(t *testing.T) {
+	searchDir := t.TempDir()
+	mustWriteIntegrationTestFile(t, searchDir, "z [*]_test.go", "TestZulu", "TestAlpha")
+	mustWriteIntegrationTestFile(t, searchDir, "a_test.go", "TestCharlie", "TestBravo")
+	weightsFile := mustWriteWeightsFile(t, `{"_default": 1}`)
+	var first string
+	for run := 0; run < 5; run++ {
+		stdout, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "3", "", weightsFile, "")
+		if err != nil {
+			t.Fatalf("run %d failed: %v\nstderr:\n%s", run, err, stderr)
+		}
+		if run == 0 {
+			first = stdout
+		} else if stdout != first {
+			t.Fatalf("run %d was not byte-stable:\nfirst: %s\ncurrent: %s", run, first, stdout)
+		}
+	}
+	got := matrixTestNames(t, first)
+	want := []string{"TestAlpha", "TestBravo", "TestCharlie", "TestZulu"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("matrix union differs: got %v, want %v", got, want)
+	}
+}
+
+func TestGenerateIntegrationMatrixUsesLongestProcessingTimeWeights(t *testing.T) {
+	searchDir := t.TempDir()
+	mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestDelta", "TestCharlie", "TestBravo", "TestAlpha")
+	weightsFile := mustWriteWeightsFile(t, `{"_default":1,"TestAlpha":1e100,"TestBravo":20,"TestCharlie":19,"TestDelta":1}`)
+	stdout, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", "", weightsFile, "")
+	if err != nil {
+		t.Fatalf("generator failed: %v\nstderr:\n%s", err, stderr)
+	}
+	matrix := parseIntegrationMatrix(t, stdout)
+	want := []string{"TestAlpha", "TestBravo|TestCharlie|TestDelta"}
+	got := []string{matrix.Include[0].TestPattern, matrix.Include[1].TestPattern}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected weighted allocation: got %v, want %v", got, want)
+	}
+}
+
+func TestGenerateIntegrationMatrixRejectsInvalidWeights(t *testing.T) {
+	for _, contents := range []string{"", " \n", `{} {}`, `not-json`, `{"_default":false}`, `{"_default":-1}`, `{"TestAlpha":"heavy"}`} {
+		searchDir := t.TempDir()
+		mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha")
+		_, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", "", mustWriteWeightsFile(t, contents), "")
+		if err == nil || !strings.Contains(stderr, "invalid weights file") {
+			t.Fatalf("weights %q: got err=%v stderr=%q", contents, err, stderr)
+		}
+	}
+}
+
+func TestGenerateIntegrationMatrixHandlesInputBoundaries(t *testing.T) {
+	t.Run("empty directory", func(t *testing.T) {
+		_, stderr, err := runGenerateIntegrationMatrix(t, t.TempDir(), "2", "", "", "")
+		if err == nil || !strings.Contains(stderr, "No test files found") {
+			t.Fatalf("expected empty input error, got err=%v stderr=%q", err, stderr)
+		}
+	})
+	t.Run("custom pattern", func(t *testing.T) {
+		searchDir := t.TempDir()
+		mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha", "TestBeta", "TestGamma")
+		stdout, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", "(TestAlpha|TestGamma)", "", "")
+		if err != nil {
+			t.Fatalf("generator failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if got, want := matrixTestNames(t, stdout), []string{"TestAlpha", "TestGamma"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("custom pattern selected %v, want %v", got, want)
+		}
+	})
+	t.Run("custom pattern without matches", func(t *testing.T) {
+		searchDir := t.TempDir()
+		mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha")
+		_, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", "TestMissing", "", "")
+		if err == nil || !strings.Contains(stderr, "No tests matching 'TestMissing'") {
+			t.Fatalf("expected no matches error, got err=%v stderr=%q", err, stderr)
+		}
+	})
+	t.Run("more partitions than tests", func(t *testing.T) {
+		searchDir := t.TempDir()
+		mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha", "TestBeta")
+		for _, partitions := range []string{"100000", "18446744073709551616"} {
+			stdout, stderr, err := runGenerateIntegrationMatrix(t, searchDir, partitions, "", "", "")
+			if err != nil {
+				t.Fatalf("partitions %s failed: %v\nstderr:\n%s", partitions, err, stderr)
+			}
+			matrix := parseIntegrationMatrix(t, stdout)
+			if len(matrix.Include) != 2 || !reflect.DeepEqual(matrixTestNames(t, stdout), []string{"TestAlpha", "TestBeta"}) {
+				t.Fatalf("partitions %s produced %+v", partitions, matrix.Include)
+			}
+		}
+	})
+}
+
+func TestGenerateIntegrationMatrixRejectsInvalidArguments(t *testing.T) {
+	searchDir := t.TempDir()
+	mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha")
+	for _, partitions := range []string{"0", "-1", "many"} {
+		_, stderr, err := runGenerateIntegrationMatrix(t, searchDir, partitions, "", "", "")
+		if err == nil || !strings.Contains(stderr, "partitions must be a positive integer") {
+			t.Fatalf("partitions %q: expected validation error, got err=%v stderr=%q", partitions, err, stderr)
+		}
+	}
+	for _, pattern := range []string{"TestAlpha\n.*", "TestAlpha\r.*"} {
+		_, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", pattern, "", "")
+		if err == nil || !strings.Contains(stderr, "test pattern must not contain") {
+			t.Fatalf("pattern %q: got err=%v stderr=%q", pattern, err, stderr)
+		}
+	}
+}
+
+func TestGenerateIntegrationMatrixFailsClosedOnToolErrors(t *testing.T) {
+	tests := []struct{ command, script, want string }{
+		{"awk", "", "missing required commands: awk"},
+		{"sort", "#!/bin/bash\n/usr/bin/head -c 1\nexit 17\n", "failed to discover test files"},
+		{"grep", "#!/bin/bash\nprintf '%s\\n' 'func TestPartial(t *testing.T) {}'\nexit 2\n", "failed to extract test names"},
+	}
+	for _, tc := range tests {
+		searchDir, binDir := t.TempDir(), t.TempDir()
+		mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha")
+		for _, name := range []string{"awk", "find", "grep", "sed", "sort", "tr"} {
+			path := filepath.Join(binDir, name)
+			if name == tc.command {
+				if tc.script != "" {
+					if err := os.WriteFile(path, []byte(tc.script), 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				continue
+			}
+			target, err := exec.LookPath(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, path); err != nil {
+				t.Fatal(err)
+			}
+		}
+		stdout, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", "", "", binDir)
+		if err == nil || stdout != "" || !strings.Contains(stderr, tc.want) {
+			t.Fatalf("%s: stdout=%q err=%v stderr=%q", tc.command, stdout, err, stderr)
+		}
+	}
+}
+
+func runGenerateIntegrationMatrix(t *testing.T, searchDir, partitions, pattern, weightsFile, path string) (string, string, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/bin/bash", "./generate-integration-matrix.sh", searchDir, partitions, pattern)
+	cmd.Dir = "."
+	for _, variable := range os.Environ() {
+		if strings.HasPrefix(variable, "OBI_INTEGRATION_TEST_WEIGHTS_FILE=") || path != "" && strings.HasPrefix(variable, "PATH=") {
+			continue
+		}
+		cmd.Env = append(cmd.Env, variable)
+	}
+	if weightsFile == "" {
+		weightsFile = filepath.Join(searchDir, "missing-weights.json")
+	}
+	cmd.Env = append(cmd.Env, "OBI_INTEGRATION_TEST_WEIGHTS_FILE="+weightsFile)
+	if path != "" {
+		cmd.Env = append(cmd.Env, "PATH="+path)
+	}
+	stdout, err := cmd.Output()
+	if err == nil {
+		return string(stdout), "", nil
+	}
+	var stderr string
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		stderr = string(exitErr.Stderr)
+	}
+	return string(stdout), stderr, err
+}
+
+func parseIntegrationMatrix(t *testing.T, stdout string) integrationMatrix {
+	t.Helper()
+	var matrix integrationMatrix
+	if err := json.Unmarshal([]byte(stdout), &matrix); err != nil {
+		t.Fatalf("failed to parse matrix JSON %q: %v", stdout, err)
+	}
+	return matrix
+}
+
+func matrixTestNames(t *testing.T, stdout string) []string {
+	t.Helper()
+	matrix := parseIntegrationMatrix(t, stdout)
+	seen := map[string]bool{}
+	var names []string
+	for _, shard := range matrix.Include {
+		for _, name := range strings.Split(shard.TestPattern, "|") {
+			if seen[name] {
+				t.Fatalf("test %s appears more than once", name)
+			}
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func mustWriteIntegrationTestFile(t *testing.T, rootDir, name string, testNames ...string) {
+	t.Helper()
+	contents := "package fixture\n\nfunc " + strings.Join(testNames, "(t *testing.T) {}\n\nfunc ") + "(t *testing.T) {}\n"
+	if err := os.WriteFile(filepath.Join(rootDir, name), []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWriteWeightsFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "weights.json")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/scripts/lint-schema-filter.jq
+++ b/scripts/lint-schema-filter.jq
@@ -40,7 +40,7 @@ map(select(
         and ($dup.attribute_id
              | IN("messaging.system", "gen_ai.provider.name", "gen_ai.operation.name",
                   "openai.api.type", "telemetry.sdk.language", "db.system.name",
-                  "rpc.system.name", "error.type"))
+                  "rpc.system.name", "error.type", "network.type"))
         and ((($dup.group_ids // []) | sort) as $groups
              | ($groups | length) == 2
                and ($groups[0] | startswith("registry."))

--- a/scripts/lint_schema_filter_test.go
+++ b/scripts/lint_schema_filter_test.go
@@ -99,6 +99,12 @@ const expectedEnumOverrideDuplicates = `[{
 		"attribute_id": "error.type",
 		"group_ids": ["registry.error", "x.obi.error"]
 	}}
+}, {
+	"diagnostic": {"severity": "Error"},
+	"error": {"DuplicateAttributeId": {
+		"attribute_id": "network.type",
+		"group_ids": ["registry.network", "x.obi.network"]
+	}}
 }]`
 
 func TestLintSchemaFilterAllowsExpectedEnumOverrideDuplicates(t *testing.T) {


### PR DESCRIPTION
## Summary

Wires `weaver registry live-check` into all 11 Kubernetes/kind suites that
export telemetry over OTLP, enforcing from day one (no observe mode): any
actionable semconv advisory fails the suite. The 5 remaining k8s suites
(`prom`, `informer_cache`, `netolly_multizone_prom`, `netolly_promexport`,
`netolly_tc_promexport`) export Prometheus directly with no OTLP path, so
weaver cannot see them.

## Review guide

55 files, but only ~10 carry logic; the other ~45 are mechanical repetition.
Suggested reading order:

**Review closely — the actual design (5 files):**
1. `internal/test/integration/components/kube/weaver.go` (new) — the whole
   validation harness: the `weaverRecorder` adapter, the Finish hook, the
   wait-for-HTTP / drain / stop / empty-report-retry sequence. Start here.
2. `internal/test/integration/components/kube/kind.go` — the `WeaverValidation()`
   option, Finish-func wiring, and the exit-code enforcement (incl. the
   `os.Exit(code)` setup-failure fix). ~49 lines.
3. `internal/test/integration/configs/otelcol-config-k8s-weavercol.yml` (new) —
   the intermediate collector: `interval` aggregation + drop-on-overflow. This
   is where the two-hop back-pressure rationale lives (see "How it works").
4. `internal/test/integration/configs/otelcol-config-k8s-weaver.yml` (new) —
   the suite otelcol "tap" that forwards to weavercol while leaving the
   existing prometheus/jaeger assertion paths byte-identical.
5. `schemas/obi/groups/{network,service_graph,k8s}.yaml` (new/extended) —
   semconv declarations; needs a domain eye on attribute names, types, and
   stability. All driven by observed live-check failures (see "Registry
   additions").

**Review once — new infra manifests, mostly declarative wiring (5 files):**
6. `k8s/manifests/08-weaver.yml` (new) — weaver + weavercol pods, registry
   PV/PVC, admin port, `runAsUser: 0`.
7. `k8s/manifests/08-weaver-multi-node.yml` (new) — **diff against #6**; it's
   the same manifest plus `nodeAffinity` pinning to the `otel` zone node.
8. `k8s/manifests/03-otelcol-weaver{,-multi-node}.yml` (new) — otelcol
   manifests that mount the tapped config from #4.
9. `k8s/manifests/00-kind{,-multi-node,-multi-zone}.yml` — +7-9 lines each:
   the `obi-registry` extraMount and the 4320→32320 admin port mapping.

**Skim for consistency — mechanical, no logic (~45 files):**
- **11 suite `*_main_test.go`**: identical 5-line opt-in (swap
  `03-otelcol.yml` → `03-otelcol-weaver.yml`, add `kube.WeaverValidation()`,
  deploy `08-weaver.yml`). Read one (`otel/k8s_main_test.go`); the rest match,
  with multi-node suites using the `-multi-node` manifest variants.
- **~28 `05-*` / `06-*` manifests + `k8s/common/k8s_metrics_testfuncs.go` +
  `configs/obi-config-promscrape.yml`**: pure `deployment.environment` →
  `deployment.environment.name` rename (the testfuncs diff is 30/30 with the
  rest being gofmt column re-alignment). No logic change.

## How it works

- **`08-weaver.yml` / `08-weaver-multi-node.yml`**: in-cluster weaver pod
  (same image pin as compose/OATS) reading the registry from an `obi-registry`
  kind extraMount, writing its report to the shared `testoutput` mount. Admin
  port exposed to the host via kind extraPortMapping 4320→32320. The
  multi-node variant is nodeAffinity-pinned to the `otel`-zone node that
  carries the mount + port mapping. The pod runs `runAsUser: 0`: the shared
  `testoutput` hostPath is root-owned on a fresh CI node, and the weaver
  image's default `uid=1000` cannot create the `weaver-out` subdirectory
  there — same reason the docker-compose weaver sets `user: "0:0"` and OBI
  writes to the mount as root.
- **`03-otelcol-weaver.yml` + `configs/otelcol-config-k8s-weaver.yml`**:
  otelcol variant (same 0.104.0 pin as the base suites) that, besides the
  existing prometheus/jaeger paths, forwards metrics + traces to a small
  dedicated **`weavercol`** collector (contrib 0.155.0, in 08-weaver*.yml)
  which aggregates and relays to weaver. The two-hop design is load-bearing:
  weaver validates every sample and is slow at netolly-scale cardinality;
  when the suite collector exported to weaver directly, its sending queue
  filled and the enqueue failure propagated synchronously through the shared
  OTLP receiver back to OBI, starving the production prometheus path the
  suites assert on (observed: OBI logging "sending queue is full" while test
  queries returned empty). weavercol ingests instantly, so weaver
  back-pressure surfaces there and reaches the suite collector only as an
  asynchronous send failure — dropped and logged, never failing OBI's
  export. weavercol also runs a 10s `interval` aggregation so weaver sees
  each unique series shape instead of every 10ms data point — netolly report
  generation dropped from ~190s to seconds.
- **`kube.WeaverValidation()` option + teardown hook** (components/kube/
  weaver.go): suites opt in via a `NewKind` option; validation runs as the
  first e2e-framework `Finish` func — after all tests, while the cluster is
  still up, before log export and cluster destruction. The validation waits
  for weaver's admin port to answer HTTP (image pull can finish after the
  suite's tests start; a bare TCP dial is not enough because kind's port
  mapping accepts and resets), drains 25s (covers weavercol's interval tick
  + gRPC reconnect backoff), POSTs /stop, fetches the report via the shared
  `weavercheck.FetchReport`, and retries the whole stop/fetch cycle up to 3
  times if the report has zero samples (weaver's pod restarts after /stop
  and OBI keeps emitting, so a weaver that came up mid-suite recovers) —
  guarding against vacuous passes. Archives the report next to the kind
  logs and runs the shared `weavercheck.Validate`.
- **Enforcement is out of band, on purpose**: e2e-framework logs `Finish`
  errors at `klog.V(2)` only and drops them from the exit code ("attempt to
  gracefully clean up. Upon error, log and continue"), and `Finish` funcs
  carry no `*testing.T` — still true in v0.7.0. So validation runs against a
  small `weaverRecorder` adapter implementing `weavercheck.TestingT`
  (failures logged loudly via slog, `FailNow` = `runtime.Goexit` on a
  dedicated goroutine, mirroring `testing.T` semantics for the `require`
  calls inside the shared validator); a recorded failure makes `kube.Kind.Run`
  exit non-zero. The `weaverRecorder` is also the single place the
  `weaver(k8s):` log prefix is applied, so the shared (prefix-less)
  `weavercheck.Validate` output is tagged consistently. The trade-off vs. a
  per-suite last-running test: the failure is package-level (no named failing
  test in `go test` output) in exchange for zero per-suite boilerplate and no
  reliance on test ordering.

## Bugs found by the wiring itself

1. **`kube.Kind.Run` swallowed setup failures** (components/kube/kind.go): a
   suite whose cluster/image/manifest setup failed but whose teardown
   succeeded exited 0 and read as `ok` — CI could silently green-light a
   broken suite. Now `os.Exit(code)` on non-zero.
2. **Deprecated `deployment.environment`** baked into 28 k8s test manifests
   and shared assertions — renamed to the current semconv
   `deployment.environment.name` (weaver flagged the deprecation on
   `target_info`). This includes the snake_case spelling
   `extra_resource_attributes: ["deployment_environment"]` in
   `configs/obi-config-promscrape.yml` (the allowlist OBI's own prometheus
   exporter uses for `target_info`), which the dotted-name sweep initially
   missed — the `prom` suite asserts on that label and fails without it.

## Registry additions (all driven by observed live-check failures)

- `schemas/obi/groups/k8s.yaml` (new): `k8s.owner.name`, `k8s.kind` — OBI's
  k8s decorator output (pkg/transform/k8s.go), observed on `target_info`.
- `schemas/obi/groups/network.yaml`: the 14 `k8s.src.*` / `k8s.dst.*` flow
  endpoint attributes (observed on `obi.network.flow.bytes` in all three
  netolly suites), ref'd on both flow metrics which share the attach path.
  GeoIP attributes deliberately NOT declared (not observed — feature off in
  these suites).
- `schemas/obi/groups/service_graph.yaml`: legacy underscored k8s peer labels
  (`client_k8s_namespace_name`, `server_k8s_namespace_name`,
  `client_k8s_cluster_name`, `server_k8s_cluster_name`), observed on the
  service-graph metrics in the `otel` suite.

`make lint-schema` passes with all additions.

## Suite plumbing changes

- `sharedpidns` routed its traces directly to jaeger, so weaver saw nothing —
  now routes through the weaver-tapped otelcol, which forwards to jaeger
  (assertions unchanged). Flagged by the new empty-report guard.
- Weaver manifests must not start with a `---` separator after the comment
  header: e2e-framework's decoder rejects the empty leading YAML document
  (`Object 'Kind' is missing in 'null'`).

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
