### PR TITLE
redis fixes

### DIFF
--- a/bpf/common/common.h
+++ b/bpf/common/common.h
@@ -130,7 +130,8 @@ typedef struct kafka_go_req {
 typedef struct redis_client_req {
     u8 type; // Must be first
     u8 err;
-    u8 _pad[6];
+    u16 buf_len;
+    u8 _pad[4];
     u64 start_monotime_ns;
     u64 end_monotime_ns;
     pid_info pid;

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -277,6 +277,9 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
         }
     }
     if (!existing) {
+        // Determining the server information for unix sockets is only valid on request creation
+        const bool is_server = is_listening(pid_conn->conn.d_port, netns) ||
+                               is_unix_sock_server(direction, orig_dport);
         if (direction == TCP_RECV) {
             cp_support_data_t *tk = bpf_map_lookup_elem(&cp_support_connect_info, pid_conn);
             if (tk && tk->real_client) {
@@ -292,6 +295,18 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
                     "Got receive as first operation for part client connection, ignoring...");
                 return;
             }
+            // pre-agent client connection: receive-first here is a spontaneous reply,
+            // registering it would invert the request/response roles
+            if (!is_server) {
+                connection_info_part_t server_part = {};
+                populate_ephemeral_info(
+                    &server_part, &pid_conn->conn, orig_dport, pid_conn->pid, FD_SERVER);
+                if (!fd_info_for_conn(&server_part)) {
+                    bpf_dbg_printk("Got receive as first operation for stale client "
+                                   "connection, ignoring...");
+                    return;
+                }
+            }
         } else {
             connection_info_part_t server_part = {};
             populate_ephemeral_info(
@@ -306,10 +321,6 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
 
         tcp_req_t *req = empty_tcp_req();
         if (req) {
-            // Determining the server information for unix sockets is only valid on request creation
-            const bool is_server = is_listening(pid_conn->conn.d_port, netns) ||
-                                   is_unix_sock_server(direction, orig_dport);
-
             req->is_server = is_server;
             int original_bytes_len = bytes_len;
             bpf_clamp_umax(bytes_len, k_tcp_max_len);

--- a/bpf/gotracer/go_redis.c
+++ b/bpf/gotracer/go_redis.c
@@ -35,6 +35,7 @@ static __always_inline void setup_request(void *goroutine_addr) {
 
     if (req) {
         req->type = EVENT_GO_REDIS;
+        req->buf_len = 0;
         req->start_monotime_ns = bpf_ktime_get_ns();
 
         go_addr_key_t g_key = {};
@@ -171,7 +172,12 @@ int obi_uprobe_redis_with_writer_ret(struct pt_regs *ctx) {
                 bpf_dbg_printk("buf=%llx, buf=[%s], len=%ld", buf, buf, len);
 
                 if (len > 0) {
-                    bpf_probe_read(&req->buf, k_redis_max_len, buf);
+                    if (len > k_redis_max_len) {
+                        len = k_redis_max_len;
+                    }
+                    if (bpf_probe_read(&req->buf, len, buf) == 0) {
+                        req->buf_len = len;
+                    }
                 }
             }
         }

--- a/internal/test/integration/components/nodebullmq/Dockerfile
+++ b/internal/test/integration/components/nodebullmq/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-slim@sha256:d8a35d586fad3af7abb6fdb9ba972388395405f4d462da9e4a4ddcde67b5e0fb
+
+WORKDIR /
+
+COPY internal/test/integration/components/nodebullmq .
+
+RUN npm ci
+
+EXPOSE 3040
+
+CMD [ "node", "worker" ]

--- a/internal/test/integration/components/nodebullmq/package-lock.json
+++ b/internal/test/integration/components/nodebullmq/package-lock.json
@@ -1,0 +1,112 @@
+{
+    "name": "nodebullmq",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "nodebullmq",
+            "version": "1.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "ioredis": "^5.4.1"
+            }
+        },
+        "node_modules/@ioredis/commands": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+            "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+            "license": "MIT"
+        },
+        "node_modules/cluster-key-slot": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+            "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/ioredis": {
+            "version": "5.11.1",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+            "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+            "license": "MIT",
+            "dependencies": {
+                "@ioredis/commands": "1.10.0",
+                "cluster-key-slot": "1.1.1",
+                "debug": "4.4.3",
+                "denque": "2.1.0",
+                "redis-errors": "1.2.0",
+                "redis-parser": "3.0.0",
+                "standard-as-callback": "2.1.0"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ioredis"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+            "license": "MIT",
+            "dependencies": {
+                "redis-errors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-as-callback": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+            "license": "MIT"
+        }
+    }
+}

--- a/internal/test/integration/components/nodebullmq/package.json
+++ b/internal/test/integration/components/nodebullmq/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "nodebullmq",
+    "version": "1.0.0",
+    "description": "BullMQ-style blocking Redis worker test server",
+    "main": "worker.js",
+    "scripts": {
+        "start": "node worker.js"
+    },
+    "license": "Apache-2.0",
+    "dependencies": {
+        "ioredis": "^5.4.1"
+    }
+}

--- a/internal/test/integration/components/nodebullmq/worker.js
+++ b/internal/test/integration/components/nodebullmq/worker.js
@@ -1,0 +1,70 @@
+// BullMQ-style worker: a long-lived ioredis connection parked in a blocking
+// BZPOPMIN, plus a producer connection. Both connections are established at
+// boot, before the agent attaches, which is the scenario under test: the
+// blocking reply is the first traffic the agent observes on the worker
+// connection.
+const http = require("http");
+const Redis = require("ioredis");
+
+const QUEUE = "bullmq:jobs";
+const PORT = 3040;
+// large enough that command capture must flow through the TCP large-buffer
+// path (inline capture is 256B), small enough to fit a 4KB buffer_sizes.tcp
+const BIG_PAYLOAD = "x".repeat(3800) + "-tailmarker";
+
+const worker = new Redis({ host: "redis", port: 6379 });
+const producer = new Redis({ host: "redis", port: 6379 });
+
+let ready = false;
+let jobsDone = 0;
+
+async function workerLoop() {
+  for (;;) {
+    const job = await worker.bzpopmin(QUEUE, 5);
+    if (!job) {
+      continue;
+    }
+    // BullMQ runs its job state machine through Lua scripts; a missing sha
+    // reproduces the NOSCRIPT error path
+    await worker
+      .evalsha("0000000000000000000000000000000000000000", 1, "bullmq:state")
+      .catch(() => {});
+    await worker.get("bullmq:state");
+    await worker.set("bullmq:state", job[1]);
+    await worker.set("bullmq:payload", BIG_PAYLOAD);
+    await worker.get("bullmq:payload");
+    jobsDone++;
+  }
+}
+
+async function main() {
+  await worker.ping();
+  await producer.ping();
+  ready = true;
+  workerLoop();
+
+  http
+    .createServer(async (req, res) => {
+      if (req.url === "/health") {
+        res.writeHead(ready ? 200 : 503);
+        res.end(ready ? "ok" : "starting");
+        return;
+      }
+      if (req.url === "/job") {
+        await producer.zadd(QUEUE, Date.now(), "job-" + Date.now());
+        res.writeHead(200);
+        res.end("queued");
+        return;
+      }
+      if (req.url === "/done") {
+        res.writeHead(200);
+        res.end(String(jobsDone));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    })
+    .listen(PORT);
+}
+
+main();

--- a/internal/test/integration/components/pythonredis/main.py
+++ b/internal/test/integration/components/pythonredis/main.py
@@ -70,6 +70,33 @@ def redis_error_test():
     try_redis_command(redis_cli, 'EVALSHA', 'INVALID_SHA', '0')
     return 'done', 200
 
+resp3_conn = None
+resp3_cli = None
+
+@app.get("/redis-resp3")
+def redis_resp3_test():
+    global resp3_conn
+    global resp3_cli
+    if resp3_conn is None:
+        resp3_cli = redis.Redis(
+            host='redis',
+            port=6379,
+            decode_responses=True,
+            protocol=3  # RESP3: map/set/boolean/double/null reply frames
+        )
+        resp3_conn = resp3_cli.ping()
+
+    # each op's reply is a RESP3-only frame type
+    resp3_cli.sadd('obi-resp3-set', 'a', 'b')
+    resp3_cli.sismember('obi-resp3-set', 'a')   # boolean #
+    resp3_cli.smembers('obi-resp3-set')         # set ~
+    resp3_cli.hset('obi-resp3-hash', mapping={'name': 'John', 'age': 29})
+    resp3_cli.hgetall('obi-resp3-hash')         # map %
+    resp3_cli.zadd('obi-resp3-zset', {'m1': 1.5})
+    resp3_cli.zscore('obi-resp3-zset', 'm1')    # double ,
+    resp3_cli.get('obi-resp3-missing')          # null _
+    return 'done', 200
+
 @app.get("/redis-db")
 def redis_error_test():
     db1_redis_cli = redis.Redis(

--- a/internal/test/integration/docker-compose-nodejs-bullmq.yml
+++ b/internal/test/integration/docker-compose-nodejs-bullmq.yml
@@ -1,0 +1,120 @@
+version: "3.8"
+
+services:
+  redis:
+    build:
+      context: ../../../internal/test/integration/components/redis/
+      dockerfile: Dockerfile
+    image: redis
+
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/nodebullmq/Dockerfile
+    image: hatest-testserver-node-bullmq
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3040/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
+      interval: 1s
+      timeout: 2s
+      retries: 30
+    depends_on:
+      otelcol:
+        condition: service_started
+      redis:
+        condition: service_started
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-nodejs-bullmq:/var/run/obi
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config-redis.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_TRACES_INSTRUMENTATIONS: "redis"
+      OTEL_EBPF_METRICS_INSTRUMENTATIONS: "redis"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+      # route capture through the TCP large-buffer path
+      OTEL_EBPF_BPF_BUFFER_SIZE_TCP: "4096"
+    depends_on:
+      # service_healthy is the point of this suite: the worker's blocking Redis
+      # connections must exist before the agent attaches
+      testserver:
+        condition: service_healthy
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.156.0@sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318:4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+      jaeger:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.60@sha256:4fd2d70fa347d6a47e79fcb06b1c177e6079f92cba88b083153d56263082135e
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=debug

--- a/internal/test/integration/red_test_nodejs_bullmq.go
+++ b/internal/test/integration/red_test_nodejs_bullmq.go
@@ -1,0 +1,148 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration // import "go.opentelemetry.io/obi/internal/test/integration"
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
+)
+
+// The worker establishes its Redis connections before the agent attaches (the
+// compose file orders the agent after the worker's healthcheck) and parks in a
+// blocking BZPOPMIN, so the first traffic the agent sees on that connection is
+// a spontaneous reply. Before the receive-first fix this lost every span on the
+// blocking connection and leaked reversed server-side spans named after reply
+// payloads.
+func testREDMetricsNodeBullMQ(t *testing.T) {
+	const url = "http://localhost:8382"
+
+	// each job wakes the worker: bzpopmin reply + evalsha + get + set
+	for i := 0; i < 4; i++ {
+		ti.DoHTTPGet(t, url+"/job", 200)
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	// ioredis sends lowercase command words on the wire
+	for _, op := range []string{"bzpopmin", "evalsha", "get", "set", "zadd"} {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			results, err := pq.Query(`db_client_operation_duration_seconds_count{` +
+				`db_operation_name="` + op + `",` +
+				`service_namespace="integration-test"}`)
+			require.NoError(ct, err, "failed to query prometheus for %s", op)
+			enoughPromResults(ct, results)
+			val := totalPromCount(ct, results)
+			assert.LessOrEqual(ct, 3, val, "expected at least 3 %s operations, got %d", op, val)
+		}, testTimeout, 100*time.Millisecond)
+	}
+
+	// reversed events used to surface as spans named after reply payload tokens
+	results, err := pq.Query(`db_client_operation_duration_seconds_count{db_operation_name=~"job-.*|bullmq.*"}`)
+	require.NoError(t, err)
+	require.Empty(t, results, "found spans named after reply payloads: %v", results)
+
+	spans := []TestCaseSpan{
+		{
+			Name: "bzpopmin",
+			Attributes: []attribute.KeyValue{
+				attribute.String("db.operation.name", "bzpopmin"),
+			},
+		},
+		{
+			Name: "evalsha",
+			Attributes: []attribute.KeyValue{
+				attribute.String("db.operation.name", "evalsha"),
+				attribute.Bool("error", true),
+				attribute.String("db.response.status_code", "NOSCRIPT"),
+			},
+		},
+		{
+			Name: "set",
+			Attributes: []attribute.KeyValue{
+				attribute.String("db.operation.name", "set"),
+			},
+		},
+	}
+	for i := range spans {
+		spans[i].Attributes = append(spans[i].Attributes,
+			attribute.String("db.system.name", "redis"),
+			attribute.String("span.kind", "client"),
+			attribute.Int("server.port", 6379),
+		)
+	}
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		for _, span := range spans {
+			resp, err := http.Get(jaegerQueryURL + "?service=node&operation=" + span.Name)
+			require.NoError(ct, err, "failed to query jaeger for %s", span.Name)
+			if resp == nil {
+				return
+			}
+			require.Equal(ct, http.StatusOK, resp.StatusCode)
+			var tq jaeger.TracesQuery
+			require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+			var tags []jaeger.Tag
+			for _, attr := range span.Attributes {
+				tags = append(tags, otelAttributeToJaegerTag(attr))
+			}
+			traces := tq.FindBySpan(tags...)
+			assert.LessOrEqual(ct, 1, len(traces), "span %s with tags %v not found in traces %v", span.Name, tags, tq.Data)
+		}
+	}, testTimeout, 100*time.Millisecond)
+
+	// the worker sets a ~3.8KB value per job; the payload tail can only reach
+	// db.query.text through the TCP large-buffer path (inline capture is 256B)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=node&operation=set")
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+		found := false
+		for _, trace := range tq.Data {
+			for _, span := range trace.Spans {
+				if tag, ok := jaeger.FindIn(span.Tags, "db.query.text"); ok {
+					if text, isStr := tag.Value.(string); isStr &&
+						len(text) > 3000 && strings.HasSuffix(text, "-tailmarker") {
+						found = true
+					}
+				}
+			}
+		}
+		assert.True(ct, found, "no set span carrying the full large-buffer payload")
+	}, testTimeout, 100*time.Millisecond)
+}
+
+func waitForBullMQTestComponents(t *testing.T, url string) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		req, err := http.NewRequest(http.MethodGet, url+"/health", nil)
+		require.NoError(ct, err)
+		r, err := testHTTPClient.Do(req)
+		require.NoError(ct, err)
+		require.Equal(ct, http.StatusOK, r.StatusCode)
+
+		// the idle worker emits a bzpopmin span per 5s park cycle once the agent
+		// is attached; this doubles as the receive-first regression check, since
+		// a reversed connection never produces them
+		results, err := pq.Query(`db_client_operation_duration_seconds_count{db_operation_name="bzpopmin"}`)
+		require.NoError(ct, err)
+		require.NotEmpty(ct, results)
+	}, 2*time.Minute, time.Second)
+}

--- a/internal/test/integration/red_test_python_redis.go
+++ b/internal/test/integration/red_test_python_redis.go
@@ -174,6 +174,51 @@ func testREDMetricsPythonRedisOnly(t *testing.T) {
 			},
 		},
 		{
+			// protocol=3 client: replies arrive as RESP3 map/set/boolean/double/null
+			// frames, which the generic tracer must still detect and pair
+			Route:     "http://localhost:8381",
+			Subpath:   "redis-resp3",
+			Comm:      "python3.14",
+			Namespace: "integration-test",
+			Spans: []TestCaseSpan{
+				{
+					Name: "SISMEMBER",
+					Attributes: []attribute.KeyValue{
+						attribute.String("db.operation.name", "SISMEMBER"),
+						attribute.String("db.query.text", "SISMEMBER obi-resp3-set a"),
+					},
+				},
+				{
+					Name: "SMEMBERS",
+					Attributes: []attribute.KeyValue{
+						attribute.String("db.operation.name", "SMEMBERS"),
+						attribute.String("db.query.text", "SMEMBERS obi-resp3-set"),
+					},
+				},
+				{
+					Name: "HGETALL",
+					Attributes: []attribute.KeyValue{
+						attribute.String("db.operation.name", "HGETALL"),
+						attribute.String("db.query.text", "HGETALL obi-resp3-hash"),
+					},
+				},
+				{
+					Name: "ZSCORE",
+					Attributes: []attribute.KeyValue{
+						attribute.String("db.operation.name", "ZSCORE"),
+						attribute.String("db.query.text", "ZSCORE obi-resp3-zset m1"),
+					},
+				},
+				{
+					Name: "GET",
+					Attributes: []attribute.KeyValue{
+						attribute.String("db.operation.name", "GET"),
+						attribute.String("db.query.text", "GET obi-resp3-missing"),
+					},
+				},
+			},
+		},
+		{
 			Route:     "http://localhost:8381",
 			Subpath:   "redis-db",
 			Comm:      "python3.14",

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -661,6 +661,20 @@ func TestSuite_PythonRedis(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_NodeBullMQ(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-nodejs-bullmq.yml", path.Join(pathOutput, "test-suite-nodejs-bullmq.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3040`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8382:3040`)
+	require.NoError(t, compose.Up())
+	t.Run("Node BullMQ blocking Redis worker", func(t *testing.T) {
+		waitForBullMQTestComponents(t, "http://localhost:8382")
+		testREDMetricsNodeBullMQ(t)
+	})
+	runWeaverValidation(t)
+	require.NoError(t, compose.Close())
+}
+
 func TestSuite_Aerospike(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-aerospike.yml", path.Join(pathOutput, "test-suite-aerospike.log"))
 	require.NoError(t, err)

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -1338,7 +1338,7 @@ func spanAttributes(s *Span) SpanAttributes {
 			"errorMessage":     message,
 			"errorDescription": s.SQLErrorDescription(),
 		}
-	case EventTypeRedisServer:
+	case EventTypeRedisServer, EventTypeRedisClient:
 		return SpanAttributes{
 			"serverAddr": SpanHost(s),
 			"serverPort": strconv.Itoa(s.HostPort),

--- a/pkg/appolly/app/request/span_test.go
+++ b/pkg/appolly/app/request/span_test.go
@@ -572,7 +572,13 @@ func TestSerializeJSONSpans(t *testing.T) {
 		},
 		{
 			eventType: EventTypeRedisClient,
-			attribs:   map[string]any{},
+			attribs: map[string]any{
+				"serverAddr": "hostname",
+				"serverPort": "5678",
+				"operation":  "method",
+				"statement":  "statement",
+				"query":      "path",
+			},
 		},
 		{
 			eventType: EventTypeKafkaClient,

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -495,7 +495,7 @@ func ReadBPFTraceAsSpan(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, reco
 		span, ignore, err := ReadGoSaramaRequestIntoSpan(record)
 		return finalizeParsedSpan(parseCtx, span, ignore, err)
 	case EventTypeGoRedis:
-		span, ignore, err := ReadGoRedisRequestIntoSpan(record)
+		span, ignore, err := ReadGoRedisRequestIntoSpan(parseCtx, record)
 		return finalizeParsedSpan(parseCtx, span, ignore, err)
 	case EventTypeGoMongo:
 		span, ignore, err := ReadGoMongoRequestIntoSpan(record)

--- a/pkg/ebpf/common/redis_detect_transform.go
+++ b/pkg/ebpf/common/redis_detect_transform.go
@@ -40,6 +40,50 @@ var redisErrors = [...]struct {
 	{[]byte("READONLY "), "READONLY"},
 }
 
+// core command words per https://github.com/redis/redis/tree/unstable/src/commands;
+// only a tie-break for reversal detection, so completeness is not required
+var redisKnownOps = func() map[string]struct{} {
+	ops := map[string]struct{}{}
+	for _, op := range []string{
+		"ACL", "APPEND", "AUTH", "BGREWRITEAOF", "BGSAVE", "BITCOUNT", "BITFIELD", "BITOP", "BITPOS",
+		"BLMOVE", "BLMPOP", "BLPOP", "BRPOP", "BRPOPLPUSH", "BZMPOP", "BZPOPMAX", "BZPOPMIN",
+		"CLIENT", "CLUSTER", "COMMAND", "CONFIG", "COPY", "DBSIZE", "DEBUG", "DECR", "DECRBY",
+		"DEL", "DISCARD", "DUMP", "ECHO", "EVAL", "EVALSHA", "EVALSHA_RO", "EVAL_RO", "EXEC",
+		"EXISTS", "EXPIRE", "EXPIREAT", "EXPIRETIME", "FAILOVER", "FCALL", "FCALL_RO", "FLUSHALL",
+		"FLUSHDB", "FUNCTION", "GEOADD", "GEODIST", "GEOHASH", "GEOPOS", "GEOSEARCH",
+		"GEOSEARCHSTORE", "GET", "GETDEL", "GETEX", "GETRANGE", "GETSET", "HDEL", "HELLO",
+		"HEXISTS", "HEXPIRE", "HGET", "HGETALL", "HGETDEL", "HGETEX", "HINCRBY", "HINCRBYFLOAT",
+		"HKEYS", "HLEN", "HMGET", "HMSET", "HPERSIST", "HRANDFIELD", "HSCAN", "HSET", "HSETNX",
+		"HSTRLEN", "HTTL", "HVALS", "INCR", "INCRBY", "INCRBYFLOAT", "INFO", "KEYS", "LASTSAVE",
+		"LATENCY", "LCS", "LINDEX", "LINSERT", "LLEN", "LMOVE", "LMPOP", "LOLWUT", "LPOP", "LPOS",
+		"LPUSH", "LPUSHX", "LRANGE", "LREM", "LSET", "LTRIM", "MEMORY", "MGET", "MIGRATE",
+		"MONITOR", "MOVE", "MSET", "MSETNX", "MULTI", "OBJECT", "PERSIST", "PEXPIRE", "PEXPIREAT",
+		"PEXPIRETIME", "PFADD", "PFCOUNT", "PFMERGE", "PING", "PSETEX", "PSUBSCRIBE", "PSYNC",
+		"PTTL", "PUBLISH", "PUBSUB", "PUNSUBSCRIBE", "QUIT", "RANDOMKEY", "RENAME", "RENAMENX",
+		"REPLICAOF", "RESET", "RESTORE", "ROLE", "RPOP", "RPOPLPUSH", "RPUSH", "RPUSHX", "SADD",
+		"SAVE", "SCAN", "SCARD", "SCRIPT", "SDIFF", "SDIFFSTORE", "SELECT", "SET", "SETEX",
+		"SETNX", "SETRANGE", "SHUTDOWN", "SINTER", "SINTERCARD", "SINTERSTORE", "SISMEMBER",
+		"SLAVEOF", "SLOWLOG", "SMEMBERS", "SMISMEMBER", "SMOVE", "SORT", "SORT_RO", "SPOP",
+		"SRANDMEMBER", "SREM", "SSCAN", "STRLEN", "SUBSCRIBE", "SUNION", "SUNIONSTORE", "SWAPDB",
+		"SYNC", "TIME", "TOUCH", "TTL", "TYPE", "UNLINK", "UNSUBSCRIBE", "UNWATCH", "WAIT",
+		"WAITAOF", "WATCH", "XACK", "XADD", "XAUTOCLAIM", "XCLAIM", "XDEL", "XGROUP", "XINFO",
+		"XLEN", "XPENDING", "XRANGE", "XREAD", "XREADGROUP", "XREVRANGE", "XSETID", "XTRIM",
+		"ZADD", "ZCARD", "ZCOUNT", "ZDIFF", "ZDIFFSTORE", "ZINCRBY", "ZINTER", "ZINTERCARD",
+		"ZINTERSTORE", "ZLEXCOUNT", "ZMPOP", "ZMSCORE", "ZPOPMAX", "ZPOPMIN", "ZRANDMEMBER",
+		"ZRANGE", "ZRANGEBYLEX", "ZRANGEBYSCORE", "ZRANGESTORE", "ZRANK", "ZREM",
+		"ZREMRANGEBYLEX", "ZREMRANGEBYRANK", "ZREMRANGEBYSCORE", "ZREVRANGE", "ZREVRANGEBYLEX",
+		"ZREVRANGEBYSCORE", "ZREVRANK", "ZSCAN", "ZSCORE", "ZUNION", "ZUNIONSTORE",
+	} {
+		ops[op] = struct{}{}
+	}
+	return ops
+}()
+
+func isKnownRedisOp(op string) bool {
+	_, ok := redisKnownOps[strings.ToUpper(op)]
+	return ok
+}
+
 func isRedis(buf *largebuf.LargeBuffer) bool {
 	if buf.Len() < minRedisFrameLen {
 		return false
@@ -111,96 +155,236 @@ func crlfTerminatedMatch(buf []uint8, matches func(c uint8) bool) bool {
 	return buf[i+1] == '\n'
 }
 
-func isValidRedisChar(c byte) bool {
-	return (c >= 'a' && c <= 'z') ||
-		(c >= 'A' && c <= 'Z') ||
-		(c >= '0' && c <= '9') ||
-		c == '.' || c == ' ' || c == '-' || c == '_'
+type redisCommand struct {
+	op   string
+	text string
 }
 
-func parseRedisRequest(buf []byte) (string, string, bool) {
-	// We need at least two CRLF-delimited lines: a first delimiter must exist with
-	// content following it. Walking the buffer directly with bytes.Index avoids the
-	// generic split.Iterator's per-call indirect dispatch and the double scan its
-	// peek-then-Reset pattern required.
-	firstDelim := bytes.Index(buf, redisDelimBytes)
-	if firstDelim < 0 || firstDelim+len(redisDelimBytes) >= len(buf) {
-		return "", "", false
-	}
+type redisReply struct {
+	status  int
+	dbError request.DBError
+}
 
-	// It's not a command, something else?
-	if buf[0] != '*' {
-		return "", "", true
+// readRESPLine returns the bytes before the next CRLF and the offset just past it
+func readRESPLine(buf []byte, pos int) ([]byte, int, bool) {
+	rel := bytes.Index(buf[pos:], redisDelimBytes)
+	if rel < 0 {
+		return nil, 0, false
+	}
+	return buf[pos : pos+rel], pos + rel + len(redisDelimBytes), true
+}
+
+func parseRESPInt(line []byte) (int, bool) {
+	if len(line) == 0 {
+		return 0, false
+	}
+	i := 0
+	neg := false
+	if line[0] == '-' {
+		neg = true
+		i = 1
+	}
+	if i >= len(line) {
+		return 0, false
+	}
+	n := 0
+	for ; i < len(line); i++ {
+		c := line[i]
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + int(c-'0')
+		if n > 1<<30 {
+			return 0, false
+		}
+	}
+	if neg {
+		n = -n
+	}
+	return n, true
+}
+
+// letters plus '.', '_', '-' (JSON.SET, EVALSHA_RO, RESTORE-ASKING); reply payload tokens rarely fit
+func isRedisCommandToken(tok []byte) bool {
+	if len(tok) == 0 {
+		return false
+	}
+	for _, c := range tok {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && c != '.' && c != '_' && c != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func isPrintableToken(tok []byte) bool {
+	for _, c := range tok {
+		if c < 0x20 || c > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+func salvageRedisCommand(op string, text *strings.Builder) *redisCommand {
+	if op == "" {
+		return nil
+	}
+	return &redisCommand{op: op, text: text.String()}
+}
+
+// parseRedisCommand reads one RESP array at pos, honoring bulk lengths so binary
+// values can't derail the scan; on truncation it salvages the complete tokens and returns ok=false
+//
+//nolint:cyclop
+func parseRedisCommand(buf []byte, pos int) (*redisCommand, int, bool) {
+	header, next, ok := readRESPLine(buf, pos)
+	if !ok || len(header) < 2 || header[0] != '*' {
+		return nil, 0, false
+	}
+	n, ok := parseRESPInt(header[1:])
+	if !ok || n <= 0 {
+		// *-1 and *0 are reply shapes, not commands
+		return nil, 0, false
 	}
 
 	op := ""
-
+	textDone := false
 	var text strings.Builder
-	// The assembled text is always shorter than the raw frame (it drops the RESP
-	// length markers and CRLFs), so a single Grow sizes the builder once and avoids
-	// the geometric re-allocations Write would otherwise trigger as tokens accumulate.
-	text.Grow(len(buf))
+	pos = next
 
-	read := false
-
-	// Resume past the array-header line; subsequent lines alternate length markers
-	// and data tokens.
-	for pos := firstDelim + len(redisDelimBytes); pos < len(buf); {
-		line := buf[pos:]
-		if rel := bytes.Index(line, redisDelimBytes); rel >= 0 {
-			end := rel + len(redisDelimBytes)
-			line, pos = line[:end], pos+end
-		} else {
-			pos = len(buf)
+	for i := 0; i < n; i++ {
+		lenLine, tokStart, ok := readRESPLine(buf, pos)
+		if !ok || len(lenLine) < 2 || lenLine[0] != '$' {
+			return salvageRedisCommand(op, &text), 0, false
 		}
-
-		if bytes.Equal(line, redisDelimBytes) {
-			continue
+		l, ok := parseRESPInt(lenLine[1:])
+		if !ok || l < 0 {
+			return salvageRedisCommand(op, &text), 0, false
 		}
-
-		if !read {
-			if isRedisOp(line) {
-				read = true
+		tokEnd := tokStart + l
+		if tokEnd+len(redisDelimBytes) > len(buf) ||
+			!bytes.Equal(buf[tokEnd:tokEnd+len(redisDelimBytes)], redisDelimBytes) {
+			return salvageRedisCommand(op, &text), 0, false
+		}
+		tok := buf[tokStart:tokEnd]
+		if i == 0 {
+			if !isRedisCommandToken(tok) {
+				return nil, 0, false
+			}
+			op = string(tok)
+			text.Write(tok)
+		} else if !textDone {
+			if isPrintableToken(tok) {
+				text.WriteByte(' ')
+				text.Write(tok)
 			} else {
-				break
+				textDone = true
 			}
-		} else {
-			if isRedisOp(line) {
-				text.WriteString("; ")
-				continue
-			}
-			if !isValidRedisChar(line[0]) {
-				break
-			}
-
-			trimmed := bytes.TrimSuffix(line, redisDelimBytes)
-
-			if op == "" {
-				op = string(trimmed)
-			}
-			text.Write(trimmed)
-			text.WriteString(" ")
-			read = false
 		}
+		pos = tokEnd + len(redisDelimBytes)
 	}
 
-	return op, strings.TrimSpace(text.String()), true
+	return &redisCommand{op: op, text: text.String()}, pos, true
 }
 
-func redisStatus(buf *largebuf.LargeBuffer) (request.DBError, int) {
-	if buf.Len() == 0 {
-		return request.DBError{}, 0
+// parseRedisCommands splits a buffer into its pipelined commands; nil means
+// the buffer isn't a command stream (how replies are told apart from commands)
+func parseRedisCommands(buf []byte) []redisCommand {
+	var cmds []redisCommand
+	pos := 0
+	for pos < len(buf) && buf[pos] == '*' {
+		cmd, next, ok := parseRedisCommand(buf, pos)
+		if cmd != nil {
+			cmds = append(cmds, *cmd)
+		}
+		if !ok {
+			break
+		}
+		pos = next
 	}
-	data := buf.UnsafeView()
-	if data[0] != '-' {
-		return request.DBError{}, 0
+	return cmds
+}
+
+const maxRESPDepth = 8
+
+// skipRESPValue advances past one RESP value of any type, including RESP3 frames
+//
+//nolint:cyclop
+func skipRESPValue(buf []byte, pos, depth int) (int, bool) {
+	if depth > maxRESPDepth || pos >= len(buf) {
+		return 0, false
 	}
-	dbError, isError := getRedisError(data[1:])
-	status := 0
-	if isError {
-		status = 1
+	t := buf[pos]
+	line, next, ok := readRESPLine(buf, pos)
+	if !ok {
+		return 0, false
 	}
-	return dbError, status
+	switch t {
+	case '+', '-', ':', ',', '(', '#', '_':
+		return next, true
+	case '$', '=':
+		l, ok := parseRESPInt(line[1:])
+		if !ok {
+			return 0, false
+		}
+		if l < 0 {
+			return next, true
+		}
+		end := next + l + len(redisDelimBytes)
+		if end > len(buf) {
+			return 0, false
+		}
+		return end, true
+	case '*', '~', '>', '%':
+		n, ok := parseRESPInt(line[1:])
+		if !ok {
+			return 0, false
+		}
+		if n < 0 {
+			return next, true
+		}
+		if t == '%' {
+			n *= 2
+		}
+		for i := 0; i < n; i++ {
+			next, ok = skipRESPValue(buf, next, depth+1)
+			if !ok {
+				return 0, false
+			}
+		}
+		return next, true
+	}
+	return 0, false
+}
+
+// parseRedisReplies splits the response stream into per-command results; RESP3
+// push frames are skipped since they aren't positional replies
+func parseRedisReplies(buf []byte, maxReplies int) []redisReply {
+	replies := make([]redisReply, 0, min(maxReplies, 8))
+	pos := 0
+	for pos < len(buf) && len(replies) < maxReplies {
+		isPush := buf[pos] == '>'
+		isErr := buf[pos] == '-'
+		next, ok := skipRESPValue(buf, pos, 0)
+		if !ok {
+			break
+		}
+		if !isPush {
+			r := redisReply{}
+			if isErr {
+				line, _, _ := readRESPLine(buf, pos)
+				dbError, known := getRedisError(line[1:])
+				r.dbError = dbError
+				if known {
+					r.status = 1
+				}
+			}
+			replies = append(replies, r)
+		}
+		pos = next
+	}
+	return replies
 }
 
 func getRedisDB(connInfo BpfConnectionInfoT, op, text string, dbCache *simplelru.LRU[BpfConnectionInfoT, int]) (int, bool) {
@@ -272,12 +456,34 @@ func TCPToRedisToSpan(trace *TCPRequestInfo, op, text string, status, db int, db
 	}
 }
 
-func ReadGoRedisRequestIntoSpan(record *ringbuf.Record) (request.Span, bool, error) {
+func ReadGoRedisRequestIntoSpan(parseCtx *EBPFParseContext, record *ringbuf.Record) (request.Span, bool, error) {
 	event, err := ReinterpretCast[GoRedisClientInfo](record.RawSample)
 	if err != nil {
 		return request.Span{}, true, err
 	}
 
+	cmds := parseRedisCommands(event.Buf[:])
+	if len(cmds) == 0 {
+		// We know it's redis request here, it just didn't complete correctly
+		event.Err = 1
+		return goRedisSpan(event, "", ""), false, nil
+	}
+
+	spans := make([]request.Span, 0, len(cmds))
+	for i := range cmds {
+		spans = append(spans, goRedisSpan(event, cmds[i].op, cmds[i].text))
+	}
+	if len(spans) > 1 {
+		// clear SpanID on extras so tracesgen assigns fresh IDs
+		for i := 1; i < len(spans); i++ {
+			spans[i].SpanID = trace2.SpanID{}
+		}
+		parseCtx.emitExtraSpans(spans[1:]...)
+	}
+	return spans[0], false, nil
+}
+
+func goRedisSpan(event *GoRedisClientInfo, op, text string) request.Span {
 	peer := ""
 	hostname := ""
 	hostPort := 0
@@ -285,13 +491,6 @@ func ReadGoRedisRequestIntoSpan(record *ringbuf.Record) (request.Span, bool, err
 	if event.Conn.S_port != 0 || event.Conn.D_port != 0 {
 		peer, hostname = (*BPFConnInfo)(unsafe.Pointer(&event.Conn)).reqHostInfo()
 		hostPort = int(event.Conn.D_port)
-	}
-
-	op, text, ok := parseRedisRequest(event.Buf[:])
-
-	if !ok {
-		// We know it's redis request here, it just didn't complete correctly
-		event.Err = 1
 	}
 
 	return request.Span{
@@ -315,5 +514,5 @@ func ReadGoRedisRequestIntoSpan(record *ringbuf.Record) (request.Span, bool, err
 			UserPID:   app.PID(event.Pid.UserPid),
 			Namespace: event.Pid.Ns,
 		},
-	}, false, nil
+	}
 }

--- a/pkg/ebpf/common/redis_detect_transform.go
+++ b/pkg/ebpf/common/redis_detect_transform.go
@@ -106,9 +106,19 @@ func isRedisOp(buf []uint8) bool {
 	case '-':
 		_, isError := getRedisError(buf[1:])
 		return isError
-	case ':', '$', '*':
+	case ':', '$', '*', '(', '!', '=', '%', '~', '>', '|':
 		return crlfTerminatedMatch(buf[1:], func(c uint8) bool {
 			return (c >= '0' && c <= '9') || c == '-'
+		})
+	case '#':
+		return len(buf) >= 4 && (buf[1] == 't' || buf[1] == 'f') && buf[2] == '\r' && buf[3] == '\n'
+	case '_':
+		return len(buf) >= 3 && buf[1] == '\r' && buf[2] == '\n'
+	case ',':
+		// RESP3 double: numbers plus inf/nan and exponent notation
+		return crlfTerminatedMatch(buf[1:], func(c uint8) bool {
+			return (c >= '0' && c <= '9') || c == '-' || c == '+' || c == '.' ||
+				c == 'e' || c == 'E' || c == 'i' || c == 'n' || c == 'f' || c == 'a'
 		})
 	}
 
@@ -323,7 +333,7 @@ func skipRESPValue(buf []byte, pos, depth int) (int, bool) {
 	switch t {
 	case '+', '-', ':', ',', '(', '#', '_':
 		return next, true
-	case '$', '=':
+	case '$', '=', '!':
 		l, ok := parseRESPInt(line[1:])
 		if !ok {
 			return 0, false
@@ -336,7 +346,7 @@ func skipRESPValue(buf []byte, pos, depth int) (int, bool) {
 			return 0, false
 		}
 		return end, true
-	case '*', '~', '>', '%':
+	case '*', '~', '>', '%', '|':
 		n, ok := parseRESPInt(line[1:])
 		if !ok {
 			return 0, false
@@ -344,7 +354,7 @@ func skipRESPValue(buf []byte, pos, depth int) (int, bool) {
 		if n < 0 {
 			return next, true
 		}
-		if t == '%' {
+		if t == '%' || t == '|' {
 			n *= 2
 		}
 		for i := 0; i < n; i++ {
@@ -359,25 +369,37 @@ func skipRESPValue(buf []byte, pos, depth int) (int, bool) {
 }
 
 // parseRedisReplies splits the response stream into per-command results; RESP3
-// push frames are skipped since they aren't positional replies
+// push frames aren't positional replies and attributes decorate the next value,
+// so both are skipped
 func parseRedisReplies(buf []byte, maxReplies int) []redisReply {
 	replies := make([]redisReply, 0, min(maxReplies, 8))
 	pos := 0
 	for pos < len(buf) && len(replies) < maxReplies {
-		isPush := buf[pos] == '>'
-		isErr := buf[pos] == '-'
+		t := buf[pos]
 		next, ok := skipRESPValue(buf, pos, 0)
 		if !ok {
 			break
 		}
-		if !isPush {
+		if t != '>' && t != '|' {
 			r := redisReply{}
-			if isErr {
+			switch t {
+			case '-':
 				line, _, _ := readRESPLine(buf, pos)
 				dbError, known := getRedisError(line[1:])
 				r.dbError = dbError
 				if known {
 					r.status = 1
+				}
+			case '!':
+				// RESP3 bulk error: text is on the line after the length header
+				if _, tstart, ok := readRESPLine(buf, pos); ok {
+					if line, _, ok := readRESPLine(buf, tstart); ok {
+						dbError, known := getRedisError(line)
+						r.dbError = dbError
+						if known {
+							r.status = 1
+						}
+					}
 				}
 			}
 			replies = append(replies, r)

--- a/pkg/ebpf/common/redis_detect_transform.go
+++ b/pkg/ebpf/common/redis_detect_transform.go
@@ -462,7 +462,7 @@ func ReadGoRedisRequestIntoSpan(parseCtx *EBPFParseContext, record *ringbuf.Reco
 		return request.Span{}, true, err
 	}
 
-	cmds := parseRedisCommands(event.Buf[:])
+	cmds := parseRedisCommands(event.Buf[:min(int(event.BufLen), len(event.Buf))])
 	if len(cmds) == 0 {
 		// We know it's redis request here, it just didn't complete correctly
 		event.Err = 1

--- a/pkg/ebpf/common/redis_detect_transform_test.go
+++ b/pkg/ebpf/common/redis_detect_transform_test.go
@@ -501,7 +501,7 @@ func TestRedisParsingTruncationSweep(t *testing.T) {
 		}
 	}
 
-	replies := []byte("+OK\r\n-ERR boom\r\n$5\r\nhello\r\n*2\r\n$1\r\na\r\n:1\r\n%1\r\n+k\r\n_\r\n>2\r\n+p\r\n+q\r\n,3.14\r\n#t\r\n(42\r\n=5\r\ntxt:x\r\n$-1\r\n*-1\r\n")
+	replies := []byte("+OK\r\n-ERR boom\r\n$5\r\nhello\r\n*2\r\n$1\r\na\r\n:1\r\n%1\r\n+k\r\n_\r\n>2\r\n+p\r\n+q\r\n,3.14\r\n#t\r\n(42\r\n=5\r\ntxt:x\r\n!8\r\nERR boom\r\n|1\r\n+k\r\n,90\r\n$-1\r\n*-1\r\n")
 	for i := 0; i <= len(replies); i++ {
 		parseRedisReplies(replies[:i], 32)
 	}
@@ -534,6 +534,113 @@ func FuzzMatchRedis(f *testing.F) {
 		ctx := NewEBPFParseContext(nil, nil, nil)
 		event := makeRedisTCPEvent(directionSend)
 		_, _, _, _ = matchRedis(ctx, event, largebuf.NewLargeBufferFrom(req), largebuf.NewLargeBufferFrom(resp))
+	})
+}
+
+// RESP3 servers (go-redis v9, redis-py protocol=3) reply with map/set/push/
+// boolean/double/null/big-number/verbatim/bulk-error/attribute frames; the
+// detector and the reply splitter must accept all of them
+func TestRedisRESP3(t *testing.T) {
+	t.Run("resp3 reply frames pass detection", func(t *testing.T) {
+		for _, reply := range []string{
+			"%2\r\n$4\r\nrole\r\n$6\r\nmaster\r\n$4\r\nmode\r\n$10\r\nstandalone\r\n",
+			"~2\r\n$1\r\na\r\n$1\r\nb\r\n",
+			">2\r\n$7\r\nmessage\r\n$5\r\nhello\r\n",
+			"#t\r\n",
+			"#f\r\n",
+			"_\r\n",
+			",3.14\r\n",
+			",-inf\r\n",
+			"(123456789012345678901234567890\r\n",
+			"=15\r\ntxt:Some string\r\n",
+			"!21\r\nSYNTAX invalid syntax\r\n",
+			"|1\r\n+key-popularity\r\n,90.0\r\n",
+		} {
+			assert.True(t, isRedis(largebuf.NewLargeBufferFrom([]byte(reply))),
+				"reply %q must be detected as redis", reply)
+		}
+	})
+
+	t.Run("garbage after resp3 markers is still rejected", func(t *testing.T) {
+		for _, buf := range []string{
+			"%abc\r\n",
+			"#x\r\n",
+			",abc\r\n",
+			"_x\r\n",
+			"~foo\r\n",
+		} {
+			assert.False(t, isRedisOp([]byte(buf)), "%q must not be detected as redis", buf)
+		}
+	})
+
+	t.Run("hello with map reply matches", func(t *testing.T) {
+		span, _, ignore, matched := runMatchRedis(t, directionSend,
+			respArray("hello", "3"),
+			[]byte("%2\r\n$4\r\nrole\r\n$6\r\nmaster\r\n$4\r\nmode\r\n$10\r\nstandalone\r\n"))
+		assert.True(t, matched)
+		assert.False(t, ignore)
+		assert.Equal(t, "hello", span.Method)
+		assert.Equal(t, 0, span.Status)
+	})
+
+	t.Run("boolean double and null replies pair positionally", func(t *testing.T) {
+		req := respPipeline(
+			respArray("SISMEMBER", "s", "m"),
+			respArray("ZSCORE", "z", "m"),
+			respArray("GET", "missing"),
+		)
+		resp := []byte("#t\r\n,3.14\r\n_\r\n")
+
+		first, extra, _, matched := runMatchRedis(t, directionSend, req, resp)
+		require.True(t, matched)
+		spans := append([]request.Span{first}, extra...)
+		require.Len(t, spans, 3)
+		for i, s := range spans {
+			assert.Equal(t, 0, s.Status, "span %d", i)
+		}
+	})
+
+	t.Run("resp3 bulk error sets status and db error", func(t *testing.T) {
+		span, _, _, matched := runMatchRedis(t, directionSend,
+			respArray("GET", "k"), []byte("!13\r\nERR bad thing\r\n"))
+		assert.True(t, matched)
+		assert.Equal(t, 1, span.Status)
+		assert.Equal(t, "ERR", span.DBError.ErrorCode)
+		assert.Equal(t, "ERR bad thing", span.DBError.Description)
+	})
+
+	t.Run("push frame between replies does not shift pairing", func(t *testing.T) {
+		req := respPipeline(respArray("GET", "k1"), respArray("GET", "k2"))
+		resp := []byte("$2\r\nv1\r\n>3\r\n$7\r\nmessage\r\n$2\r\nch\r\n$2\r\nhi\r\n-ERR boom\r\n")
+
+		first, extra, _, matched := runMatchRedis(t, directionSend, req, resp)
+		require.True(t, matched)
+		spans := append([]request.Span{first}, extra...)
+		require.Len(t, spans, 2)
+		assert.Equal(t, 0, spans[0].Status)
+		assert.Equal(t, 1, spans[1].Status)
+		assert.Equal(t, "ERR", spans[1].DBError.ErrorCode)
+	})
+
+	t.Run("attribute frame decorates the next reply without shifting pairing", func(t *testing.T) {
+		req := respPipeline(respArray("GET", "k1"), respArray("GET", "k2"))
+		resp := []byte("|1\r\n$14\r\nkey-popularity\r\n%1\r\n$7\r\nkey:123\r\n,90.0\r\n:1\r\n-ERR boom\r\n")
+
+		first, extra, _, matched := runMatchRedis(t, directionSend, req, resp)
+		require.True(t, matched)
+		spans := append([]request.Span{first}, extra...)
+		require.Len(t, spans, 2)
+		assert.Equal(t, 0, spans[0].Status)
+		assert.Equal(t, 1, spans[1].Status)
+	})
+
+	t.Run("reversed event with resp3 map reply as request", func(t *testing.T) {
+		span, _, ignore, matched := runMatchRedis(t, directionRecv,
+			[]byte("%1\r\n$4\r\nmode\r\n$10\r\nstandalone\r\n"), respArray("hello", "3"))
+		assert.True(t, matched)
+		assert.False(t, ignore)
+		assert.Equal(t, request.EventTypeRedisClient, span.Type)
+		assert.Equal(t, "hello", span.Method)
 	})
 }
 

--- a/pkg/ebpf/common/redis_detect_transform_test.go
+++ b/pkg/ebpf/common/redis_detect_transform_test.go
@@ -6,11 +6,14 @@ package ebpfcommon
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
 
@@ -18,12 +21,6 @@ type crlfTest struct {
 	testStr string
 	result  bool
 }
-
-var (
-	benchmarkRedisOp   string
-	benchmarkRedisText string
-	benchmarkRedisOK   bool
-)
 
 func TestCRLFMatching(t *testing.T) {
 	for _, ts := range []crlfTest{
@@ -40,134 +37,6 @@ func TestCRLFMatching(t *testing.T) {
 		})
 		assert.Equal(t, res, ts.result)
 	}
-}
-
-func BenchmarkParseRedisRequest(b *testing.B) {
-	tests := []struct {
-		name   string
-		input  []byte
-		wantOK bool
-	}{
-		{
-			name:   "get",
-			input:  redisBenchmarkCommand("GET", "session-key"),
-			wantOK: true,
-		},
-		{
-			name:   "set",
-			input:  redisBenchmarkCommand("SET", "session-key", "session-value"),
-			wantOK: true,
-		},
-		{
-			name:   "mget_many_keys",
-			input:  redisBenchmarkMGet(32),
-			wantOK: true,
-		},
-		{
-			name:   "pipeline_get",
-			input:  redisBenchmarkPipeline(16, "GET", "session-key"),
-			wantOK: true,
-		},
-		{
-			name: "client_setinfo",
-			input: []byte(fmt.Sprintf(
-				"*4\r\n$6\r\nclient\r\n$7\r\nsetinfo\r\n$8\r\nLIB-NAME\r\n$19\r\n%s(,go1.22.2)\r\n*4\r\n$6\r\nclient\r\n$7\r\nsetinfo\r\n$7\r\nLIB-VER\r\n$5\r\n9.5.1\r\n",
-				"go-redis",
-			)),
-			wantOK: true,
-		},
-		{
-			name:   "short_invalid",
-			input:  []byte("2"),
-			wantOK: false,
-		},
-	}
-
-	for _, tt := range tests {
-		b.Run(tt.name, func(b *testing.B) {
-			b.ReportAllocs()
-			b.SetBytes(int64(len(tt.input)))
-			b.ResetTimer()
-
-			for i := 0; i < b.N; i++ {
-				op, text, ok := parseRedisRequest(tt.input)
-				if ok != tt.wantOK {
-					b.Fatalf("parseRedisRequest ok = %v, want %v", ok, tt.wantOK)
-				}
-				benchmarkRedisOp = op
-				benchmarkRedisText = text
-				benchmarkRedisOK = ok
-			}
-		})
-	}
-}
-
-func redisBenchmarkCommand(args ...string) []byte {
-	buf := bytes.Buffer{}
-	fmt.Fprintf(&buf, "*%d\r\n", len(args))
-	for _, arg := range args {
-		fmt.Fprintf(&buf, "$%d\r\n%s\r\n", len(arg), arg)
-	}
-
-	return buf.Bytes()
-}
-
-func redisBenchmarkMGet(keys int) []byte {
-	args := make([]string, 0, keys+1)
-	args = append(args, "MGET")
-	for i := 0; i < keys; i++ {
-		args = append(args, fmt.Sprintf("session-key:%02d", i))
-	}
-
-	return redisBenchmarkCommand(args...)
-}
-
-func redisBenchmarkPipeline(commands int, args ...string) []byte {
-	buf := bytes.Buffer{}
-	for i := 0; i < commands; i++ {
-		buf.Write(redisBenchmarkCommand(args...))
-	}
-
-	return buf.Bytes()
-}
-
-func TestRedisParsing(t *testing.T) {
-	proper := []byte("*2\r\n$3\r\nGET\r\n$5\r\nobi")
-
-	op, text, ok := parseRedisRequest(proper)
-	assert.True(t, ok)
-	assert.Equal(t, "GET", op)
-	assert.Equal(t, "GET obi", text)
-
-	weird := []byte("*2\r\nGET\r\nobi")
-	op, text, ok = parseRedisRequest(weird)
-	assert.True(t, ok)
-	assert.Empty(t, op)
-	assert.Empty(t, text)
-
-	unknown := []byte("2\r\nGET\r\nobi")
-	op, text, ok = parseRedisRequest(unknown)
-	assert.True(t, ok)
-	assert.Empty(t, op)
-	assert.Empty(t, text)
-
-	op, text, ok = parseRedisRequest([]byte("2"))
-	assert.False(t, ok)
-	assert.Empty(t, op)
-	assert.Empty(t, text)
-
-	multi := []byte(fmt.Sprintf("*4\r\n$6\r\nclient\r\n$7\r\nsetinfo\r\n$8\r\nLIB-NAME\r\n$19\r\n%s(,go1.22.2)\r\n*4\r\n$6\r\nclient\r\n$7\r\nsetinfo\r\n$7\r\nLIB-VER\r\n$5\r\n9.5.1\r\n", "go-redis"))
-	op, text, ok = parseRedisRequest(multi)
-	assert.True(t, ok)
-	assert.Equal(t, "client", op)
-	assert.Equal(t, "client setinfo LIB-NAME go-redis(,go1.22.2) ; client setinfo LIB-VER 9.5.1", text)
-
-	hmset := []byte{42, 52, 13, 10, 36, 53, 13, 10, 72, 77, 83, 69, 84, 13, 10, 36, 51, 54, 13, 10, 48, 99, 57, 102, 97, 56, 97, 97, 45, 50, 56, 49, 102, 45, 49, 49, 101, 102, 45, 57, 55, 98, 57, 45, 98, 101, 57, 54, 48, 48, 99, 97, 48, 102, 50, 55, 13, 10, 36, 52, 13, 10, 99, 97, 114, 116, 13, 10, 36, 53, 52, 13, 10, 10, 36, 48, 99, 57, 102, 97, 56, 97, 97, 45, 50, 56, 49, 102, 45, 49, 49, 101, 102, 45, 57, 55, 98, 57, 45, 98, 101, 57, 54, 48, 48, 99, 97, 48, 102, 50, 55, 18, 14, 10, 10, 79, 76, 74, 67, 69, 83, 80, 67, 55, 90, 16, 5, 13, 10, 0, 10, 72, 81, 84, 71, 87, 71, 80, 78, 72, 52, 16, 1, 13, 10, 0, 10, 49, 89, 77, 87, 87, 78, 49, 78, 52, 79, 16, 5, 13, 10, 0, 10, 10, 57, 83, 73, 81, 84, 56, 84, 79, 74, 79, 16, 5, 13, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	op, text, ok = parseRedisRequest(hmset)
-
-	assert.True(t, ok)
-	assert.Equal(t, "HMSET", op)
-	assert.Equal(t, "HMSET 0c9fa8aa-281f-11ef-97b9-be9600ca0f27 cart", text)
 }
 
 func TestIsRedis(t *testing.T) {
@@ -220,4 +89,463 @@ func TestGetRedisDb(t *testing.T) {
 	// After quitting the connection, the db should be removed from the cache
 	_, found = getRedisDB(connInfo, "GET", "GET OBI", cache)
 	assert.False(t, found, "Expected Redis DB to not be found after quitting the connection")
+}
+
+var benchmarkRedisCmds []redisCommand
+
+func BenchmarkParseRedisCommands(b *testing.B) {
+	tests := []struct {
+		name     string
+		input    []byte
+		wantCmds int
+	}{
+		{
+			name:     "get",
+			input:    redisBenchmarkCommand("GET", "session-key"),
+			wantCmds: 1,
+		},
+		{
+			name:     "set",
+			input:    redisBenchmarkCommand("SET", "session-key", "session-value"),
+			wantCmds: 1,
+		},
+		{
+			name:     "mget_many_keys",
+			input:    redisBenchmarkMGet(32),
+			wantCmds: 1,
+		},
+		{
+			name:     "pipeline_get",
+			input:    redisBenchmarkPipeline(16, "GET", "session-key"),
+			wantCmds: 16,
+		},
+		{
+			name: "client_setinfo",
+			input: []byte(fmt.Sprintf(
+				"*4\r\n$6\r\nclient\r\n$7\r\nsetinfo\r\n$8\r\nLIB-NAME\r\n$19\r\n%s(,go1.22.2)\r\n*4\r\n$6\r\nclient\r\n$7\r\nsetinfo\r\n$7\r\nLIB-VER\r\n$5\r\n9.5.1\r\n",
+				"go-redis",
+			)),
+			wantCmds: 2,
+		},
+		{
+			name:     "short_invalid",
+			input:    []byte("2"),
+			wantCmds: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tt.input)))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				cmds := parseRedisCommands(tt.input)
+				if len(cmds) != tt.wantCmds {
+					b.Fatalf("parseRedisCommands len = %d, want %d", len(cmds), tt.wantCmds)
+				}
+				benchmarkRedisCmds = cmds
+			}
+		})
+	}
+}
+
+func redisBenchmarkCommand(args ...string) []byte {
+	buf := bytes.Buffer{}
+	fmt.Fprintf(&buf, "*%d\r\n", len(args))
+	for _, arg := range args {
+		fmt.Fprintf(&buf, "$%d\r\n%s\r\n", len(arg), arg)
+	}
+
+	return buf.Bytes()
+}
+
+func redisBenchmarkMGet(keys int) []byte {
+	args := make([]string, 0, keys+1)
+	args = append(args, "MGET")
+	for i := 0; i < keys; i++ {
+		args = append(args, fmt.Sprintf("session-key:%02d", i))
+	}
+
+	return redisBenchmarkCommand(args...)
+}
+
+func redisBenchmarkPipeline(commands int, args ...string) []byte {
+	buf := bytes.Buffer{}
+	for i := 0; i < commands; i++ {
+		buf.Write(redisBenchmarkCommand(args...))
+	}
+
+	return buf.Bytes()
+}
+
+func TestRedisParsing(t *testing.T) {
+	// declared $5 but only 3 bytes captured: the truncated token is dropped
+	proper := []byte("*2\r\n$3\r\nGET\r\n$5\r\nobi")
+	cmds := parseRedisCommands(proper)
+	require.Len(t, cmds, 1)
+	assert.Equal(t, "GET", cmds[0].op)
+	assert.Equal(t, "GET", cmds[0].text)
+
+	complete := []byte("*2\r\n$3\r\nGET\r\n$3\r\nobi\r\n")
+	cmds = parseRedisCommands(complete)
+	require.Len(t, cmds, 1)
+	assert.Equal(t, "GET", cmds[0].op)
+	assert.Equal(t, "GET obi", cmds[0].text)
+
+	weird := []byte("*2\r\nGET\r\nobi")
+	assert.Empty(t, parseRedisCommands(weird))
+
+	unknown := []byte("2\r\nGET\r\nobi")
+	assert.Empty(t, parseRedisCommands(unknown))
+
+	assert.Empty(t, parseRedisCommands([]byte("2")))
+
+	multi := []byte(fmt.Sprintf("*4\r\n$6\r\nclient\r\n$7\r\nsetinfo\r\n$8\r\nLIB-NAME\r\n$19\r\n%s(,go1.22.2)\r\n*4\r\n$6\r\nclient\r\n$7\r\nsetinfo\r\n$7\r\nLIB-VER\r\n$5\r\n9.5.1\r\n", "go-redis"))
+	cmds = parseRedisCommands(multi)
+	require.Len(t, cmds, 2)
+	assert.Equal(t, "client", cmds[0].op)
+	assert.Equal(t, "client setinfo LIB-NAME go-redis(,go1.22.2)", cmds[0].text)
+	assert.Equal(t, "client", cmds[1].op)
+	assert.Equal(t, "client setinfo LIB-VER 9.5.1", cmds[1].text)
+
+	hmset := []byte{42, 52, 13, 10, 36, 53, 13, 10, 72, 77, 83, 69, 84, 13, 10, 36, 51, 54, 13, 10, 48, 99, 57, 102, 97, 56, 97, 97, 45, 50, 56, 49, 102, 45, 49, 49, 101, 102, 45, 57, 55, 98, 57, 45, 98, 101, 57, 54, 48, 48, 99, 97, 48, 102, 50, 55, 13, 10, 36, 52, 13, 10, 99, 97, 114, 116, 13, 10, 36, 53, 52, 13, 10, 10, 36, 48, 99, 57, 102, 97, 56, 97, 97, 45, 50, 56, 49, 102, 45, 49, 49, 101, 102, 45, 57, 55, 98, 57, 45, 98, 101, 57, 54, 48, 48, 99, 97, 48, 102, 50, 55, 18, 14, 10, 10, 79, 76, 74, 67, 69, 83, 80, 67, 55, 90, 16, 5, 13, 10, 0, 10, 72, 81, 84, 71, 87, 71, 80, 78, 72, 52, 16, 1, 13, 10, 0, 10, 49, 89, 77, 87, 87, 78, 49, 78, 52, 79, 16, 5, 13, 10, 0, 10, 10, 57, 83, 73, 81, 84, 56, 84, 79, 74, 79, 16, 5, 13, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	cmds = parseRedisCommands(hmset)
+	require.Len(t, cmds, 1)
+	assert.Equal(t, "HMSET", cmds[0].op)
+	assert.Equal(t, "HMSET 0c9fa8aa-281f-11ef-97b9-be9600ca0f27 cart", cmds[0].text)
+}
+
+// respArray encodes args as a single RESP command array (the client wire format)
+func respArray(args ...string) []byte {
+	var b strings.Builder
+	fmt.Fprintf(&b, "*%d\r\n", len(args))
+	for _, a := range args {
+		fmt.Fprintf(&b, "$%d\r\n%s\r\n", len(a), a)
+	}
+	return []byte(b.String())
+}
+
+func respPipeline(cmds ...[]byte) []byte {
+	var out []byte
+	for _, c := range cmds {
+		out = append(out, c...)
+	}
+	return out
+}
+
+func makeRedisTCPEvent(direction uint8) *TCPRequestInfo {
+	i := &TCPRequestInfo{
+		StartMonotimeNs: 2000 * 1000000,
+		EndMonotimeNs:   2000 * 2 * 1000000,
+		Direction:       direction,
+	}
+	i.ConnInfo.S_addr[15] = 1
+	i.ConnInfo.S_port = 51234
+	i.ConnInfo.D_addr[15] = 2
+	i.ConnInfo.D_port = 6379
+	return i
+}
+
+func runMatchRedis(t *testing.T, direction uint8, reqBuf, respBuf []byte) (request.Span, []request.Span, bool, bool) {
+	t.Helper()
+	ctx := NewEBPFParseContext(nil, nil, nil)
+	var extra []request.Span
+	ctx.emitSpans = func(spans []request.Span) { extra = append(extra, spans...) }
+
+	event := makeRedisTCPEvent(direction)
+	span, ignore, matched, err := matchRedis(ctx, event,
+		largebuf.NewLargeBufferFrom(reqBuf), largebuf.NewLargeBufferFrom(respBuf))
+	require.NoError(t, err)
+	return span, extra, ignore, matched
+}
+
+func TestRedisMatchSimpleCommands(t *testing.T) {
+	t.Run("get with simple string reply", func(t *testing.T) {
+		span, extra, ignore, matched := runMatchRedis(t, directionSend,
+			respArray("GET", "session-key"), []byte("$5\r\nvalue\r\n"))
+		assert.True(t, matched)
+		assert.False(t, ignore)
+		assert.Empty(t, extra)
+		assert.Equal(t, request.EventTypeRedisClient, span.Type)
+		assert.Equal(t, "GET", span.Method)
+		assert.Equal(t, "GET session-key", span.Path)
+		assert.Equal(t, 0, span.Status)
+	})
+
+	t.Run("lowercase ioredis wire format", func(t *testing.T) {
+		span, _, _, matched := runMatchRedis(t, directionSend,
+			respArray("get", "blk5:business"), []byte("$2\r\nv1\r\n"))
+		assert.True(t, matched)
+		assert.Equal(t, "get", span.Method)
+	})
+
+	t.Run("blocking bzpopmin with null array timeout reply", func(t *testing.T) {
+		span, _, ignore, matched := runMatchRedis(t, directionSend,
+			respArray("bzpopmin", "blk5:queue", "5"), []byte("*-1\r\n"))
+		assert.True(t, matched)
+		assert.False(t, ignore)
+		assert.Equal(t, request.EventTypeRedisClient, span.Type)
+		assert.Equal(t, "bzpopmin", span.Method)
+	})
+
+	t.Run("blocking bzpopmin with array reply", func(t *testing.T) {
+		reply := []byte("*3\r\n$10\r\nblk5:queue\r\n$4\r\njob1\r\n$13\r\n1720000000000\r\n")
+		span, _, _, matched := runMatchRedis(t, directionSend,
+			respArray("bzpopmin", "blk5:queue", "5"), reply)
+		assert.True(t, matched)
+		assert.Equal(t, "bzpopmin", span.Method)
+	})
+
+	t.Run("evalsha bullmq style", func(t *testing.T) {
+		sha := strings.Repeat("6c4c6de2", 5)
+		span, _, _, matched := runMatchRedis(t, directionSend,
+			respArray("evalsha", sha, "1", "blk5:key"), []byte(":1\r\n"))
+		assert.True(t, matched)
+		assert.Equal(t, "evalsha", span.Method)
+		assert.Contains(t, span.Path, sha)
+	})
+
+	t.Run("unknown command word with error reply", func(t *testing.T) {
+		span, _, _, matched := runMatchRedis(t, directionSend,
+			respArray("INVALID_COMMAND"),
+			[]byte("-ERR unknown command 'INVALID_COMMAND', with args beginning with: \r\n"))
+		assert.True(t, matched)
+		assert.Equal(t, request.EventTypeRedisClient, span.Type)
+		assert.Equal(t, "INVALID_COMMAND", span.Method)
+		assert.Equal(t, 1, span.Status)
+		assert.Equal(t, "ERR", span.DBError.ErrorCode)
+		assert.Equal(t, "ERR unknown command 'INVALID_COMMAND', with args beginning with: ", span.DBError.Description)
+	})
+
+	t.Run("noscript error reply sets status and db error", func(t *testing.T) {
+		span, _, _, matched := runMatchRedis(t, directionSend,
+			respArray("evalsha", "0000000000000000000000000000000000000000", "1", "blk5:key"),
+			[]byte("-NOSCRIPT No matching script. Please use EVAL.\r\n"))
+		assert.True(t, matched)
+		assert.Equal(t, "evalsha", span.Method)
+		assert.Equal(t, 1, span.Status)
+		assert.Equal(t, "NOSCRIPT", span.DBError.ErrorCode)
+	})
+}
+
+// mid-flight attach pairs a reply buffer with a command buffer: the command must
+// be recovered from the response side and never named after reply payload tokens
+func TestRedisMatchReversedEvent(t *testing.T) {
+	t.Run("simple string reply as request", func(t *testing.T) {
+		span, _, ignore, matched := runMatchRedis(t, directionRecv,
+			[]byte("+PONG\r\n"), respArray("ping"))
+		assert.True(t, matched)
+		assert.False(t, ignore)
+		assert.Equal(t, request.EventTypeRedisClient, span.Type)
+		assert.Equal(t, "ping", span.Method)
+	})
+
+	t.Run("null array reply as request", func(t *testing.T) {
+		// bzpopmin timeout on a pre-agent connection: *-1 arrives receive-first
+		span, _, ignore, matched := runMatchRedis(t, directionRecv,
+			[]byte("*-1\r\n"), respArray("evalsha", strings.Repeat("ab", 20), "1", "blk5:key"))
+		assert.True(t, matched, "reversed event with null array request must still match")
+		assert.False(t, ignore)
+		assert.Equal(t, request.EventTypeRedisClient, span.Type)
+		assert.Equal(t, "evalsha", span.Method)
+	})
+
+	t.Run("array reply as request must not become op", func(t *testing.T) {
+		reply := []byte("*3\r\n$10\r\nblk5:queue\r\n$4\r\njob1\r\n$13\r\n1720000000000\r\n")
+		span, _, ignore, matched := runMatchRedis(t, directionRecv,
+			reply, respArray("get", "blk5:business"))
+		assert.True(t, matched)
+		assert.False(t, ignore)
+		assert.NotEqual(t, "blk5:queue", span.Method,
+			"span named after reply payload token is the reversal artifact")
+		assert.Equal(t, request.EventTypeRedisClient, span.Type)
+		assert.Equal(t, "get", span.Method)
+	})
+
+	t.Run("error reply as request", func(t *testing.T) {
+		span, _, _, matched := runMatchRedis(t, directionRecv,
+			[]byte("-NOSCRIPT No matching script. Please use EVAL.\r\n"),
+			respArray("get", "blk5:business"))
+		assert.True(t, matched)
+		assert.Equal(t, "get", span.Method)
+		assert.Equal(t, request.EventTypeRedisClient, span.Type)
+	})
+
+	t.Run("both sides replies is ignored", func(t *testing.T) {
+		_, _, ignore, matched := runMatchRedis(t, directionRecv,
+			[]byte("+OK\r\n"), []byte("+PONG\r\n"))
+		assert.True(t, matched)
+		assert.True(t, ignore)
+	})
+}
+
+// N pipelined commands in one write must produce N spans with positional statuses
+func TestRedisMatchPipeline(t *testing.T) {
+	collect := func(first request.Span, extra []request.Span) []request.Span {
+		return append([]request.Span{first}, extra...)
+	}
+
+	t.Run("three commands three replies", func(t *testing.T) {
+		req := respPipeline(
+			respArray("SET", "k1", "v1"),
+			respArray("GET", "k2"),
+			respArray("HGETALL", "users_sessions"),
+		)
+		resp := []byte("+OK\r\n$2\r\nv2\r\n*2\r\n$1\r\nf\r\n$1\r\nv\r\n")
+
+		first, extra, ignore, matched := runMatchRedis(t, directionSend, req, resp)
+		require.True(t, matched)
+		require.False(t, ignore)
+
+		spans := collect(first, extra)
+		require.Len(t, spans, 3)
+		assert.Equal(t, "SET", spans[0].Method)
+		assert.Equal(t, "SET k1 v1", spans[0].Path)
+		assert.Equal(t, "GET", spans[1].Method)
+		assert.Equal(t, "GET k2", spans[1].Path)
+		assert.Equal(t, "HGETALL", spans[2].Method)
+		for _, s := range spans {
+			assert.Equal(t, request.EventTypeRedisClient, s.Type)
+			assert.Equal(t, 0, s.Status)
+		}
+	})
+
+	t.Run("error reply in the middle is attributed to its command", func(t *testing.T) {
+		req := respPipeline(
+			respArray("SET", "k1", "v1"),
+			respArray("LPUSH", "k1", "x"),
+			respArray("GET", "k1"),
+		)
+		resp := []byte("+OK\r\n-WRONGTYPE Operation against a key holding the wrong kind of value\r\n$2\r\nv1\r\n")
+
+		first, extra, _, matched := runMatchRedis(t, directionSend, req, resp)
+		require.True(t, matched)
+
+		spans := collect(first, extra)
+		require.Len(t, spans, 3)
+		assert.Equal(t, 0, spans[0].Status)
+		assert.Equal(t, 1, spans[1].Status)
+		assert.Equal(t, "WRONGTYPE", spans[1].DBError.ErrorCode)
+		assert.Equal(t, 0, spans[2].Status)
+	})
+
+	t.Run("client setinfo pair from go-redis", func(t *testing.T) {
+		req := respPipeline(
+			respArray("client", "setinfo", "LIB-NAME", "go-redis(,go1.22.2)"),
+			respArray("client", "setinfo", "LIB-VER", "9.5.1"),
+		)
+		resp := []byte("+OK\r\n+OK\r\n")
+
+		first, extra, _, matched := runMatchRedis(t, directionSend, req, resp)
+		require.True(t, matched)
+
+		spans := collect(first, extra)
+		require.Len(t, spans, 2)
+		assert.Equal(t, "client", spans[0].Method)
+		assert.Equal(t, "client", spans[1].Method)
+	})
+
+	t.Run("truncated trailing command does not corrupt earlier spans", func(t *testing.T) {
+		full := respPipeline(
+			respArray("GET", "k1"),
+			respArray("SET", "some-long-key-name", "some-long-value"),
+		)
+		// cut inside the second command's bulk string, as the capture buffer does
+		req := full[:len(respArray("GET", "k1"))+10]
+		resp := []byte("$2\r\nv1\r\n")
+
+		first, extra, _, matched := runMatchRedis(t, directionSend, req, resp)
+		require.True(t, matched)
+
+		spans := collect(first, extra)
+		assert.Equal(t, "GET", spans[0].Method)
+		assert.Equal(t, "GET k1", spans[0].Path)
+		for _, s := range spans {
+			assert.NotContains(t, s.Path, ";")
+		}
+	})
+
+	t.Run("more commands than captured replies", func(t *testing.T) {
+		req := respPipeline(
+			respArray("GET", "k1"),
+			respArray("GET", "k2"),
+			respArray("GET", "k3"),
+		)
+		resp := []byte("$2\r\nv1\r\n")
+
+		first, extra, _, matched := runMatchRedis(t, directionSend, req, resp)
+		require.True(t, matched)
+
+		spans := collect(first, extra)
+		require.Len(t, spans, 3)
+		for i, s := range spans {
+			assert.Equal(t, "GET", s.Method, "span %d", i)
+			assert.Equal(t, 0, s.Status, "span %d has no observed error", i)
+		}
+	})
+}
+
+// capture can cut the stream at any byte: every prefix must parse without
+// panicking and never yield a command with an empty op
+func TestRedisParsingTruncationSweep(t *testing.T) {
+	full := respPipeline(
+		respArray("SET", "key", strings.Repeat("v", 300)),
+		respArray("bzpopmin", "blk5:queue", "5"),
+		respArray("evalsha", strings.Repeat("ab", 20), "1", "blk5:key"),
+	)
+	for i := 0; i <= len(full); i++ {
+		for _, cmd := range parseRedisCommands(full[:i]) {
+			assert.NotEmpty(t, cmd.op, "prefix len %d", i)
+		}
+	}
+
+	replies := []byte("+OK\r\n-ERR boom\r\n$5\r\nhello\r\n*2\r\n$1\r\na\r\n:1\r\n%1\r\n+k\r\n_\r\n>2\r\n+p\r\n+q\r\n,3.14\r\n#t\r\n(42\r\n=5\r\ntxt:x\r\n$-1\r\n*-1\r\n")
+	for i := 0; i <= len(replies); i++ {
+		parseRedisReplies(replies[:i], 32)
+	}
+}
+
+func FuzzParseRedisCommands(f *testing.F) {
+	f.Add([]byte("*2\r\n$3\r\nGET\r\n$3\r\nobi\r\n"))
+	f.Add([]byte("*-1\r\n"))
+	f.Add([]byte("*3\r\n$10\r\nblk5:queue\r\n$4\r\njob1\r\n$13\r\n1720000000000\r\n"))
+	f.Add([]byte("-NOSCRIPT No matching script. Please use EVAL.\r\n"))
+	f.Add([]byte("%2\r\n+a\r\n:1\r\n+b\r\n:2\r\n"))
+	f.Add([]byte("*1000000000\r\n$5\r\n"))
+	f.Add([]byte("$1073741823\r\nx\r\n"))
+	f.Add([]byte(">2\r\n+p\r\n+q\r\n*1\r\n$7\r\nZUNION\r\n"))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		for _, cmd := range parseRedisCommands(data) {
+			if cmd.op == "" {
+				t.Fatalf("command with empty op from %q", data)
+			}
+		}
+		parseRedisReplies(data, 32)
+	})
+}
+
+func FuzzMatchRedis(f *testing.F) {
+	f.Add([]byte("*2\r\n$3\r\nGET\r\n$3\r\nobi\r\n"), []byte("+OK\r\n"))
+	f.Add([]byte("*-1\r\n"), []byte("*1\r\n$4\r\nping\r\n"))
+	f.Add([]byte("-NOSCRIPT nope\r\n"), []byte("*2\r\n$3\r\nget\r\n$1\r\nk\r\n"))
+	f.Fuzz(func(_ *testing.T, req, resp []byte) {
+		ctx := NewEBPFParseContext(nil, nil, nil)
+		event := makeRedisTCPEvent(directionSend)
+		_, _, _, _ = matchRedis(ctx, event, largebuf.NewLargeBufferFrom(req), largebuf.NewLargeBufferFrom(resp))
+	})
+}
+
+func TestRedisReplyShapesAreNotCommands(t *testing.T) {
+	for _, reply := range []string{
+		"*-1\r\n",
+		"$-1\r\n",
+		"*3\r\n$10\r\nblk5:queue\r\n$4\r\njob1\r\n$13\r\n1720000000000\r\n",
+		"+OK\r\n",
+		"-ERR unknown command\r\n",
+		":42\r\n",
+	} {
+		assert.Empty(t, parseRedisCommands([]byte(reply)), "reply %q must not yield a command", reply)
+	}
 }

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -378,35 +378,57 @@ func matchRedis(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer
 		return request.Span{}, false, false, nil
 	}
 
-	op, text, ok := parseRedisRequest(requestBuffer.UnsafeView())
+	cmds := parseRedisCommands(requestBuffer.UnsafeView())
+	reversed := false
 
-	if !ok {
-		return request.Span{}, false, false, nil
-	}
-
-	var status int
-	var redisErr request.DBError
-
-	if op == "" {
-		op, text, ok = parseRedisRequest(responseBuffer.UnsafeView())
-		if !ok || op == "" {
-			return request.Span{}, true, true, nil // ignore if we couldn't parse it
+	// mid-flight attach can swap buffer roles (blocking-command replies arrive
+	// receive-first); the side holding a known command word wins
+	if len(cmds) == 0 || !isKnownRedisOp(cmds[0].op) {
+		if respCmds := parseRedisCommands(responseBuffer.UnsafeView()); len(respCmds) > 0 &&
+			(len(cmds) == 0 || isKnownRedisOp(respCmds[0].op)) {
+			cmds = respCmds
+			reversed = true
+			reverseTCPEvent(event)
 		}
-		// We've caught the event reversed in the middle of communication, let's
-		// reverse the event
-		reverseTCPEvent(event)
-		redisErr, status = redisStatus(requestBuffer)
-	} else {
-		redisErr, status = redisStatus(responseBuffer)
 	}
 
-	db, found := getRedisDB(event.ConnInfo, op, text, parseCtx.redisDBCache)
-
-	if !found {
-		db = -1 // if we don't have the db in cache, we assume it's not set
+	if len(cmds) == 0 {
+		return request.Span{}, true, true, nil // redis reply traffic with no command to attribute
 	}
 
-	return TCPToRedisToSpan(event, op, text, status, db, redisErr), false, true, nil
+	// reversed events pair the commands with a stale reply, so statuses are unknowable
+	var replies []redisReply
+	if !reversed {
+		replies = parseRedisReplies(responseBuffer.UnsafeView(), len(cmds))
+	}
+
+	spans := make([]request.Span, 0, len(cmds))
+	for i := range cmds {
+		cmd := &cmds[i]
+
+		status := 0
+		var redisErr request.DBError
+		if i < len(replies) {
+			status, redisErr = replies[i].status, replies[i].dbError
+		}
+
+		db, found := getRedisDB(event.ConnInfo, cmd.op, cmd.text, parseCtx.redisDBCache)
+		if !found {
+			db = -1 // if we don't have the db in cache, we assume it's not set
+		}
+
+		spans = append(spans, TCPToRedisToSpan(event, cmd.op, cmd.text, status, db, redisErr))
+	}
+
+	if len(spans) > 1 {
+		// clear SpanID on extras so tracesgen assigns fresh IDs
+		for i := 1; i < len(spans); i++ {
+			spans[i].SpanID = trace.SpanID{}
+		}
+		parseCtx.emitExtraSpans(spans[1:]...)
+	}
+
+	return spans[0], false, true, nil
 }
 
 func matchMemcached(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {


### PR DESCRIPTION
## Summary

Long-lived Redis connections that existed before OBI started no longer get their traffic misread. When a service sits in a blocking Redis command (BZPOPMIN, BLPOP, pub/sub), the reply arrives on a connection OBI never saw open. OBI used to mistake that reply for an incoming request and from then on read the whole connection backwards — dropping virtually every span and occasionally emitting nonsense spans named after response data (pong, update_in_progress). Now OBI recognizes this situation and stays correctly oriented. In practice: agent restarts/upgrades no longer silently kill Redis visibility for running workers.

When OBI does catch a connection mid-conversation, it recovers instead of dropping. If the buffers arrive role-swapped, OBI now identifies which side holds the actual command and builds the span from it.

Pipelined commands each get their own span. Clients that batch commands into one network write (node-redis auto-pipelining, ioredis/go-redis pipelines) used to produce a single span named after the first command with everything else glued into one query text. Now each command in the batch becomes its own span, and an error in the middle of a batch is attributed to the exact command that failed.

The Redis parser no longer trips over binary values. Values containing newlines or raw bytes used to derail parsing mid-command; the parser now reads the protocol's declared lengths, so binary payloads and truncated captures degrade gracefully instead of producing garbage.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
