### PR TITLE
Fix OTLP trace-export internal metrics to reflect real send outcomes

### DIFF
--- a/pkg/export/otel/metrics_export_internal_test.go
+++ b/pkg/export/otel/metrics_export_internal_test.go
@@ -20,16 +20,14 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 )
 
-// countingMetricsReporter records how many metric exports the instrumentation
-// wrapper observed as successful vs failed.
 type countingMetricsReporter struct {
 	imetrics.NoopReporter
 	exports    atomic.Int64
 	exportErrs atomic.Int64
 }
 
-func (c *countingMetricsReporter) OTELMetricExport(int)        { c.exports.Add(1) }
-func (c *countingMetricsReporter) OTELMetricExportError(error) { c.exportErrs.Add(1) }
+func (c *countingMetricsReporter) OTELMetricExport(metrics int) { c.exports.Add(int64(metrics)) }
+func (c *countingMetricsReporter) OTELMetricExportError(error)  { c.exportErrs.Add(1) }
 
 func oneResourceMetric() *metricdata.ResourceMetrics {
 	return &metricdata.ResourceMetrics{
@@ -46,11 +44,6 @@ func oneResourceMetric() *metricdata.ResourceMetrics {
 	}
 }
 
-// TestMetricsExportInternalMetrics verifies that obi.otel.metric.export(.errors)
-// reflect the real OTLP send outcome. Unlike the collector traces exporter, the
-// SDK metric exporter is synchronous (the PeriodicReader drives Export and
-// consumes its return), so the instrumentation wrapper already observes success
-// and failure directly.
 func TestMetricsExportInternalMetrics(t *testing.T) {
 	t.Run("successful export is counted", func(t *testing.T) {
 		coll := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/export/otel/metrics_export_internal_test.go
+++ b/pkg/export/otel/metrics_export_internal_test.go
@@ -1,0 +1,97 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+)
+
+// countingMetricsReporter records how many metric exports the instrumentation
+// wrapper observed as successful vs failed.
+type countingMetricsReporter struct {
+	imetrics.NoopReporter
+	exports    atomic.Int64
+	exportErrs atomic.Int64
+}
+
+func (c *countingMetricsReporter) OTELMetricExport(int)        { c.exports.Add(1) }
+func (c *countingMetricsReporter) OTELMetricExportError(error) { c.exportErrs.Add(1) }
+
+func oneResourceMetric() *metricdata.ResourceMetrics {
+	return &metricdata.ResourceMetrics{
+		ScopeMetrics: []metricdata.ScopeMetrics{{
+			Metrics: []metricdata.Metrics{{
+				Name: "test",
+				Data: metricdata.Sum[int64]{
+					Temporality: metricdata.CumulativeTemporality,
+					IsMonotonic: true,
+					DataPoints:  []metricdata.DataPoint[int64]{{Value: 1}},
+				},
+			}},
+		}},
+	}
+}
+
+// TestMetricsExportInternalMetrics verifies that obi.otel.metric.export(.errors)
+// reflect the real OTLP send outcome. Unlike the collector traces exporter, the
+// SDK metric exporter is synchronous (the PeriodicReader drives Export and
+// consumes its return), so the instrumentation wrapper already observes success
+// and failure directly.
+func TestMetricsExportInternalMetrics(t *testing.T) {
+	t.Run("successful export is counted", func(t *testing.T) {
+		coll := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer coll.Close()
+
+		base, err := otlpmetrichttp.New(context.Background(),
+			otlpmetrichttp.WithEndpointURL(coll.URL+"/v1/metrics"),
+			otlpmetrichttp.WithInsecure())
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = base.Shutdown(context.Background()) })
+
+		rep := &countingMetricsReporter{}
+		wrapped := instrumentMetricsExporter(rep, base)
+
+		require.NoError(t, wrapped.Export(context.Background(), oneResourceMetric()))
+		assert.Positive(t, rep.exports.Load(), "a successful export must increment obi.otel.metric.exports")
+		assert.Zero(t, rep.exportErrs.Load(), "a successful export must not increment obi.otel.metric.export.errors")
+	})
+
+	t.Run("failed export is counted", func(t *testing.T) {
+		coll := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		deadEndpoint := coll.URL
+		coll.Close()
+
+		base, err := otlpmetrichttp.New(context.Background(),
+			otlpmetrichttp.WithEndpointURL(deadEndpoint+"/v1/metrics"),
+			otlpmetrichttp.WithInsecure(),
+			otlpmetrichttp.WithTimeout(500*time.Millisecond),
+			otlpmetrichttp.WithRetry(otlpmetrichttp.RetryConfig{Enabled: false}))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = base.Shutdown(context.Background()) })
+
+		rep := &countingMetricsReporter{}
+		wrapped := instrumentMetricsExporter(rep, base)
+
+		require.Error(t, wrapped.Export(context.Background(), oneResourceMetric()))
+		assert.Positive(t, rep.exportErrs.Load(), "a failed export must increment obi.otel.metric.export.errors")
+		assert.Zero(t, rep.exports.Load(), "a failed export must not increment obi.otel.metric.exports")
+	})
+}

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -228,11 +228,8 @@ func instrumentTracesExporter(internalMetrics imetrics.Reporter, in exporter.Tra
 }
 
 // queueInstrumentedTraces stacks the sending queue and retry on top of the
-// instrumentation wrapper. The base exporter must be synchronous (its own queue
-// and retry disabled) so instrumentedTracesExporter observes the real export
-// outcome — a successful send or a send failure — instead of the underlying
-// exporter's sending-queue enqueue result, which always reports success and
-// hides asynchronous send failures from obi.otel.trace.export(.errors).
+// instrumentation wrapper, whose base exporter must be synchronous so it
+// observes the real send outcome instead of the sending-queue enqueue result.
 func queueInstrumentedTraces(
 	ctx context.Context,
 	set exporter.Settings,
@@ -285,9 +282,6 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		config := factory.CreateDefaultConfig().(*otlphttpexporter.Config)
 		queueCfg := getQueueConfig(cfg)
 		retryCfg := getRetrySettings(cfg)
-		// Keep the otlphttp exporter synchronous (queue and retry disabled) so the
-		// instrumentation wrapper observes real send outcomes. The outer
-		// exporterhelper below owns the queue and retry.
 		config.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
 		config.RetryConfig = configretry.BackOffConfig{Enabled: false}
 		config.ClientConfig = confighttp.ClientConfig{
@@ -315,7 +309,11 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		}
 		// TODO: remove this once the batcher helper is added to otlphttpexporter
 		wrapped, err := queueInstrumentedTraces(ctx, set, cfg, im, exp, queueCfg, retryCfg)
-		return wrapped, host, err
+		if err != nil {
+			_ = exp.Shutdown(ctx)
+			return nil, nil, err
+		}
+		return wrapped, host, nil
 	case otelcfg.ProtocolGRPC:
 		slog.Debug("instantiating GRPC TracesReporter", "protocol", proto)
 		var err error
@@ -337,9 +335,6 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		config := factory.CreateDefaultConfig().(*otlpexporter.Config)
 		queueCfg := getQueueConfig(cfg)
 		retryCfg := getRetrySettings(cfg)
-		// Keep the otlp gRPC exporter synchronous (queue and retry disabled) so the
-		// instrumentation wrapper observes real send outcomes. The outer
-		// exporterhelper below owns the queue and retry.
 		config.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
 		config.RetryConfig = configretry.BackOffConfig{Enabled: false}
 		config.ClientConfig = configgrpc.ClientConfig{
@@ -356,7 +351,11 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 			return nil, nil, err
 		}
 		wrapped, err := queueInstrumentedTraces(ctx, set, cfg, im, exp, queueCfg, retryCfg)
-		return wrapped, emptyHost{}, err
+		if err != nil {
+			_ = exp.Shutdown(ctx)
+			return nil, nil, err
+		}
+		return wrapped, emptyHost{}, nil
 	case otelcfg.ProtocolDebug:
 		slog.Debug("instantiating Debug TracesReporter", "protocol", proto)
 		factory := debugexporter.NewFactory()

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -227,6 +227,32 @@ func instrumentTracesExporter(internalMetrics imetrics.Reporter, in exporter.Tra
 	}
 }
 
+// queueInstrumentedTraces stacks the sending queue and retry on top of the
+// instrumentation wrapper. The base exporter must be synchronous (its own queue
+// and retry disabled) so instrumentedTracesExporter observes the real export
+// outcome — a successful send or a send failure — instead of the underlying
+// exporter's sending-queue enqueue result, which always reports success and
+// hides asynchronous send failures from obi.otel.trace.export(.errors).
+func queueInstrumentedTraces(
+	ctx context.Context,
+	set exporter.Settings,
+	cfg otelcfg.TracesConfig,
+	im imetrics.Reporter,
+	base exporter.Traces,
+	queueCfg configoptional.Optional[exporterhelper.QueueBatchConfig],
+	retryCfg configretry.BackOffConfig,
+) (exporter.Traces, error) {
+	instrumented := instrumentTracesExporter(im, base)
+	return exporterhelper.NewTraces(ctx, set, cfg,
+		instrumented.ConsumeTraces,
+		exporterhelper.WithStart(instrumented.Start),
+		exporterhelper.WithShutdown(instrumented.Shutdown),
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exporterhelper.WithQueue(queueCfg),
+		exporterhelper.WithRetry(retryCfg),
+	)
+}
+
 //nolint:cyclop
 func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetrics.Reporter) (exporter.Traces, component.Host, error) {
 	if cfg.TracesConsumer != nil {
@@ -257,8 +283,13 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		}
 		factory := otlphttpexporter.NewFactory()
 		config := factory.CreateDefaultConfig().(*otlphttpexporter.Config)
-		config.QueueConfig = getQueueConfig(cfg)
-		config.RetryConfig = getRetrySettings(cfg)
+		queueCfg := getQueueConfig(cfg)
+		retryCfg := getRetrySettings(cfg)
+		// Keep the otlphttp exporter synchronous (queue and retry disabled) so the
+		// instrumentation wrapper observes real send outcomes. The outer
+		// exporterhelper below owns the queue and retry.
+		config.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+		config.RetryConfig = configretry.BackOffConfig{Enabled: false}
 		config.ClientConfig = confighttp.ClientConfig{
 			Endpoint: opts.Scheme + "://" + opts.Endpoint + opts.BaseURLPath,
 			TLS: configtls.ClientConfig{
@@ -282,15 +313,8 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 			slog.Error("can't create OTLP HTTP traces exporter", "error", err)
 			return nil, nil, err
 		}
-		exp = instrumentTracesExporter(im, exp)
 		// TODO: remove this once the batcher helper is added to otlphttpexporter
-		wrapped, err := exporterhelper.NewTraces(ctx, set, cfg,
-			exp.ConsumeTraces,
-			exporterhelper.WithStart(exp.Start),
-			exporterhelper.WithShutdown(exp.Shutdown),
-			exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-			exporterhelper.WithQueue(config.QueueConfig),
-			exporterhelper.WithRetry(config.RetryConfig))
+		wrapped, err := queueInstrumentedTraces(ctx, set, cfg, im, exp, queueCfg, retryCfg)
 		return wrapped, host, err
 	case otelcfg.ProtocolGRPC:
 		slog.Debug("instantiating GRPC TracesReporter", "protocol", proto)
@@ -311,8 +335,13 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		}
 		factory := otlpexporter.NewFactory()
 		config := factory.CreateDefaultConfig().(*otlpexporter.Config)
-		config.QueueConfig = getQueueConfig(cfg)
-		config.RetryConfig = getRetrySettings(cfg)
+		queueCfg := getQueueConfig(cfg)
+		retryCfg := getRetrySettings(cfg)
+		// Keep the otlp gRPC exporter synchronous (queue and retry disabled) so the
+		// instrumentation wrapper observes real send outcomes. The outer
+		// exporterhelper below owns the queue and retry.
+		config.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+		config.RetryConfig = configretry.BackOffConfig{Enabled: false}
 		config.ClientConfig = configgrpc.ClientConfig{
 			Endpoint: grpcEndpoint,
 			TLS: configtls.ClientConfig{
@@ -326,8 +355,8 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		if err != nil {
 			return nil, nil, err
 		}
-		exp = instrumentTracesExporter(im, exp)
-		return exp, emptyHost{}, nil
+		wrapped, err := queueInstrumentedTraces(ctx, set, cfg, im, exp, queueCfg, retryCfg)
+		return wrapped, emptyHost{}, err
 	case otelcfg.ProtocolDebug:
 		slog.Debug("instantiating Debug TracesReporter", "protocol", proto)
 		factory := debugexporter.NewFactory()

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -282,8 +282,10 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		config := factory.CreateDefaultConfig().(*otlphttpexporter.Config)
 		queueCfg := getQueueConfig(cfg)
 		retryCfg := getRetrySettings(cfg)
+		disabledRetry := configretry.NewDefaultBackOffConfig()
+		disabledRetry.Enabled = false
 		config.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
-		config.RetryConfig = configretry.BackOffConfig{Enabled: false}
+		config.RetryConfig = disabledRetry
 		config.ClientConfig = confighttp.ClientConfig{
 			Endpoint: opts.Scheme + "://" + opts.Endpoint + opts.BaseURLPath,
 			TLS: configtls.ClientConfig{
@@ -335,8 +337,10 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		config := factory.CreateDefaultConfig().(*otlpexporter.Config)
 		queueCfg := getQueueConfig(cfg)
 		retryCfg := getRetrySettings(cfg)
+		disabledRetry := configretry.NewDefaultBackOffConfig()
+		disabledRetry.Enabled = false
 		config.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
-		config.RetryConfig = configretry.BackOffConfig{Enabled: false}
+		config.RetryConfig = disabledRetry
 		config.ClientConfig = configgrpc.ClientConfig{
 			Endpoint: grpcEndpoint,
 			TLS: configtls.ClientConfig{

--- a/pkg/export/otel/traces_export_metrics_test.go
+++ b/pkg/export/otel/traces_export_metrics_test.go
@@ -5,6 +5,7 @@ package otel
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -15,6 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
@@ -36,8 +39,29 @@ func oneSpan() ptrace.Traces {
 	return traces
 }
 
+type otlpTraceGRPCServer struct {
+	ptraceotlp.UnimplementedGRPCServer
+}
+
+func (*otlpTraceGRPCServer) Export(context.Context, ptraceotlp.ExportRequest) (ptraceotlp.ExportResponse, error) {
+	return ptraceotlp.NewExportResponse(), nil
+}
+
+// startOTLPTraceGRPCServer starts an in-process OTLP/gRPC trace receiver that
+// accepts every export, returning its "http://host:port" endpoint.
+func startOTLPTraceGRPCServer(t *testing.T) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	ptraceotlp.RegisterGRPCServer(srv, &otlpTraceGRPCServer{})
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+	return "http://" + lis.Addr().String()
+}
+
 func TestTracesExportInternalMetrics(t *testing.T) {
-	t.Run("successful export is counted", func(t *testing.T) {
+	t.Run("HTTP successful export is counted", func(t *testing.T) {
 		coll := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -64,7 +88,7 @@ func TestTracesExportInternalMetrics(t *testing.T) {
 		assert.Zero(t, rep.exportErrs.Load(), "a successful export must not increment obi.otel.trace.export.errors")
 	})
 
-	t.Run("failed export is counted", func(t *testing.T) {
+	t.Run("HTTP failed export is counted", func(t *testing.T) {
 		coll := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -93,5 +117,59 @@ func TestTracesExportInternalMetrics(t *testing.T) {
 		require.Eventually(t, func() bool { return rep.exportErrs.Load() > 0 }, 5*time.Second, 20*time.Millisecond,
 			"a failed export must increment obi.otel.trace.export.errors")
 		assert.Zero(t, rep.exports.Load(), "a failed export must not increment obi.otel.trace.exports")
+	})
+
+	t.Run("gRPC successful export is counted", func(t *testing.T) {
+		rep := &countingTracesReporter{}
+		// queue/batcher enabled so the export exercises the async send path
+		cfg := otelcfg.TracesConfig{
+			CommonEndpoint:   startOTLPTraceGRPCServer(t),
+			Protocol:         otelcfg.ProtocolGRPC,
+			Instrumentations: []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+			BatchMaxSize:     1,
+			QueueSize:        2,
+			BatchTimeout:     10 * time.Millisecond,
+		}
+		exp, host, err := getTracesExporter(context.Background(), cfg, rep)
+		require.NoError(t, err)
+		require.NoError(t, exp.Start(context.Background(), host))
+		t.Cleanup(func() { _ = exp.Shutdown(context.Background()) })
+
+		require.NoError(t, exp.ConsumeTraces(context.Background(), oneSpan()))
+
+		require.Eventually(t, func() bool { return rep.exports.Load() > 0 }, 5*time.Second, 20*time.Millisecond,
+			"a successful gRPC export must increment obi.otel.trace.exports")
+		assert.Zero(t, rep.exportErrs.Load(), "a successful gRPC export must not increment obi.otel.trace.export.errors")
+	})
+
+	t.Run("gRPC failed export is counted", func(t *testing.T) {
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		deadEndpoint := "http://" + lis.Addr().String()
+		require.NoError(t, lis.Close())
+
+		rep := &countingTracesReporter{}
+		// queue/batcher enabled so the export exercises the async send path
+		cfg := otelcfg.TracesConfig{
+			CommonEndpoint:         deadEndpoint,
+			Protocol:               otelcfg.ProtocolGRPC,
+			Instrumentations:       []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+			BatchMaxSize:           1,
+			QueueSize:              2,
+			BatchTimeout:           10 * time.Millisecond,
+			BackOffInitialInterval: 10 * time.Millisecond,
+			BackOffMaxInterval:     10 * time.Millisecond,
+			BackOffMaxElapsedTime:  100 * time.Millisecond,
+		}
+		exp, host, err := getTracesExporter(context.Background(), cfg, rep)
+		require.NoError(t, err)
+		require.NoError(t, exp.Start(context.Background(), host))
+		t.Cleanup(func() { _ = exp.Shutdown(context.Background()) })
+
+		_ = exp.ConsumeTraces(context.Background(), oneSpan())
+
+		require.Eventually(t, func() bool { return rep.exportErrs.Load() > 0 }, 5*time.Second, 20*time.Millisecond,
+			"a failed gRPC export must increment obi.otel.trace.export.errors")
+		assert.Zero(t, rep.exports.Load(), "a failed gRPC export must not increment obi.otel.trace.exports")
 	})
 }

--- a/pkg/export/otel/traces_export_metrics_test.go
+++ b/pkg/export/otel/traces_export_metrics_test.go
@@ -1,0 +1,102 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+)
+
+// countingTracesReporter records how many trace exports the instrumentation
+// wrapper observed as successful vs failed. Embedding NoopReporter satisfies the
+// rest of the imetrics.Reporter interface while keeping the type distinct from
+// the builtin noop (so instrumentTracesExporter actually wraps it).
+type countingTracesReporter struct {
+	imetrics.NoopReporter
+	exports    atomic.Int64
+	exportErrs atomic.Int64
+}
+
+func (c *countingTracesReporter) OTELTraceExport(int)        { c.exports.Add(1) }
+func (c *countingTracesReporter) OTELTraceExportError(error) { c.exportErrs.Add(1) }
+
+func oneSpan() ptrace.Traces {
+	traces := ptrace.NewTraces()
+	traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetName("test")
+	return traces
+}
+
+// TestTracesExportInternalMetrics verifies that obi.otel.trace.export(.errors)
+// reflect the real OTLP send outcome rather than the exporter sending-queue's
+// enqueue result. The instrumentation wraps a synchronous exporter beneath the
+// queue/retry, so a reachable collector records a success and an unreachable one
+// records an error.
+func TestTracesExportInternalMetrics(t *testing.T) {
+	t.Run("successful export is counted", func(t *testing.T) {
+		coll := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer coll.Close()
+
+		rep := &countingTracesReporter{}
+		cfg := otelcfg.TracesConfig{
+			CommonEndpoint:   coll.URL,
+			Instrumentations: []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+		}
+		exp, host, err := getTracesExporter(context.Background(), cfg, rep)
+		require.NoError(t, err)
+		require.NoError(t, exp.Start(context.Background(), host))
+		t.Cleanup(func() { _ = exp.Shutdown(context.Background()) })
+
+		require.NoError(t, exp.ConsumeTraces(context.Background(), oneSpan()))
+
+		require.Eventually(t, func() bool { return rep.exports.Load() > 0 }, 5*time.Second, 20*time.Millisecond,
+			"a successful export must increment obi.otel.trace.exports")
+		assert.Zero(t, rep.exportErrs.Load(), "a successful export must not increment obi.otel.trace.export.errors")
+	})
+
+	t.Run("failed export is counted", func(t *testing.T) {
+		// Start then immediately stop a server so its address refuses connections.
+		coll := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		deadEndpoint := coll.URL
+		coll.Close()
+
+		rep := &countingTracesReporter{}
+		cfg := otelcfg.TracesConfig{
+			CommonEndpoint:   deadEndpoint,
+			Instrumentations: []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+			// Bound the retry so ConsumeTraces gives up quickly instead of
+			// blocking on the default 5-minute backoff budget.
+			BackOffInitialInterval: 10 * time.Millisecond,
+			BackOffMaxInterval:     10 * time.Millisecond,
+			BackOffMaxElapsedTime:  100 * time.Millisecond,
+		}
+		exp, host, err := getTracesExporter(context.Background(), cfg, rep)
+		require.NoError(t, err)
+		require.NoError(t, exp.Start(context.Background(), host))
+		t.Cleanup(func() { _ = exp.Shutdown(context.Background()) })
+
+		// The send fails; ConsumeTraces surfaces the error after the bounded retry.
+		_ = exp.ConsumeTraces(context.Background(), oneSpan())
+
+		require.Eventually(t, func() bool { return rep.exportErrs.Load() > 0 }, 5*time.Second, 20*time.Millisecond,
+			"a failed export must increment obi.otel.trace.export.errors")
+		assert.Zero(t, rep.exports.Load(), "a failed export must not increment obi.otel.trace.exports")
+	})
+}

--- a/pkg/export/otel/traces_export_metrics_test.go
+++ b/pkg/export/otel/traces_export_metrics_test.go
@@ -21,17 +21,13 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 )
 
-// countingTracesReporter records how many trace exports the instrumentation
-// wrapper observed as successful vs failed. Embedding NoopReporter satisfies the
-// rest of the imetrics.Reporter interface while keeping the type distinct from
-// the builtin noop (so instrumentTracesExporter actually wraps it).
 type countingTracesReporter struct {
 	imetrics.NoopReporter
 	exports    atomic.Int64
 	exportErrs atomic.Int64
 }
 
-func (c *countingTracesReporter) OTELTraceExport(int)        { c.exports.Add(1) }
+func (c *countingTracesReporter) OTELTraceExport(spans int)  { c.exports.Add(int64(spans)) }
 func (c *countingTracesReporter) OTELTraceExportError(error) { c.exportErrs.Add(1) }
 
 func oneSpan() ptrace.Traces {
@@ -40,11 +36,6 @@ func oneSpan() ptrace.Traces {
 	return traces
 }
 
-// TestTracesExportInternalMetrics verifies that obi.otel.trace.export(.errors)
-// reflect the real OTLP send outcome rather than the exporter sending-queue's
-// enqueue result. The instrumentation wraps a synchronous exporter beneath the
-// queue/retry, so a reachable collector records a success and an unreachable one
-// records an error.
 func TestTracesExportInternalMetrics(t *testing.T) {
 	t.Run("successful export is counted", func(t *testing.T) {
 		coll := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -53,9 +44,13 @@ func TestTracesExportInternalMetrics(t *testing.T) {
 		defer coll.Close()
 
 		rep := &countingTracesReporter{}
+		// queue/batcher enabled so the export exercises the async send path
 		cfg := otelcfg.TracesConfig{
 			CommonEndpoint:   coll.URL,
 			Instrumentations: []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+			BatchMaxSize:     1,
+			QueueSize:        2,
+			BatchTimeout:     10 * time.Millisecond,
 		}
 		exp, host, err := getTracesExporter(context.Background(), cfg, rep)
 		require.NoError(t, err)
@@ -70,7 +65,6 @@ func TestTracesExportInternalMetrics(t *testing.T) {
 	})
 
 	t.Run("failed export is counted", func(t *testing.T) {
-		// Start then immediately stop a server so its address refuses connections.
 		coll := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -78,11 +72,13 @@ func TestTracesExportInternalMetrics(t *testing.T) {
 		coll.Close()
 
 		rep := &countingTracesReporter{}
+		// queue/batcher enabled so the export exercises the async send path
 		cfg := otelcfg.TracesConfig{
-			CommonEndpoint:   deadEndpoint,
-			Instrumentations: []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
-			// Bound the retry so ConsumeTraces gives up quickly instead of
-			// blocking on the default 5-minute backoff budget.
+			CommonEndpoint:         deadEndpoint,
+			Instrumentations:       []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+			BatchMaxSize:           1,
+			QueueSize:              2,
+			BatchTimeout:           10 * time.Millisecond,
 			BackOffInitialInterval: 10 * time.Millisecond,
 			BackOffMaxInterval:     10 * time.Millisecond,
 			BackOffMaxElapsedTime:  100 * time.Millisecond,
@@ -92,7 +88,6 @@ func TestTracesExportInternalMetrics(t *testing.T) {
 		require.NoError(t, exp.Start(context.Background(), host))
 		t.Cleanup(func() { _ = exp.Shutdown(context.Background()) })
 
-		// The send fails; ConsumeTraces surfaces the error after the bounded retry.
 		_ = exp.ConsumeTraces(context.Background(), oneSpan())
 
 		require.Eventually(t, func() bool { return rep.exportErrs.Load() > 0 }, 5*time.Second, 20*time.Millisecond,

--- a/pkg/export/otel/traces_export_metrics_test.go
+++ b/pkg/export/otel/traces_export_metrics_test.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
-	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"


### PR DESCRIPTION
## Summary

`obi.otel.trace.exports` and `obi.otel.trace.export.errors` did not reflect what
actually happened on the wire. In `getTracesExporter`, the OTLP exporter was
created with its own asynchronous sending queue, and the instrumentation wrapper
(`instrumentedTracesExporter`) sat *above* that queue. `ConsumeTraces` therefore
returned as soon as the batch was **enqueued** — always success — while the real
HTTP/gRPC send (and any failure) happened later on the exporter's internal
goroutine, invisible to the wrapper.

Observable effect, against an unreachable collector:

| | `trace.exports` | `trace.export.errors` |
|---|---|---|
| before | counts up (false — these are enqueues) | never increments |
| after | `0` | counts real connection failures |

### Change

`getTracesExporter` now keeps the underlying otlphttp / otlpgrpc exporter
**synchronous** (its own queue and retry disabled) and stacks the sending queue
and retry on an outer `exporterhelper` whose base consume function is the
instrumentation wrapper (`queueInstrumentedTraces`). The wrapper is now invoked
by the queue consumer with the real send result, so:

- `obi.otel.trace.exports` counts genuinely delivered batches, not enqueues.
- `obi.otel.trace.export.errors` counts real send failures (per attempt).

Applied to both the HTTP and gRPC paths (gRPC previously had no outer helper at
all, so it now matches HTTP). This also removes the redundant double-queue on the
HTTP path — the exporter's internal queue plus the outer `exporterhelper` queue
were both configured from the same settings.

### Metrics exporter — no change needed

`obi.otel.metric.exports` / `obi.otel.metric.export.errors` were already correct:
the metrics path uses the OTel **SDK** exporter (`otlpmetrichttp` / `grpc`) driven
by a synchronous `PeriodicReader`, which has no async sending queue — the wrapper
already observes the real `Export()` outcome. A regression test is added to lock
this in.

## Validation

New unit tests in `pkg/export/otel`:

- `TestTracesExportInternalMetrics` — a reachable collector records a success on
  `trace.exports`; an unreachable endpoint records `trace.export.errors` (the
  case that was impossible before). The tests **enable the sending queue** so
  they exercise the async path; the failure case was confirmed to fail on the
  pre-fix code and pass on the fix.
- `TestMetricsExportInternalMetrics` — same success/failure coverage for the
  metrics exporter, locking in that it already observes real outcomes.

End-to-end on a live OBI instance:

- Traces to a dead endpoint → `obi_otel_trace_export_errors_total` increments
  (`connect: connection refused`) with `trace_exports` at `0`; healthy endpoint →
  `trace_exports` climbs, errors stay flat.
- Metrics to a dead endpoint (internal metrics observed via the Prometheus
  exporter) → `obi_otel_metric_export_errors_total` increments, confirming the
  metrics path already surfaces real failures.

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
