### PR TITLE
Weaver 0.25.1 Modernization: `.weaver.toml` live-check filtering + compact report over HTTP `/stop`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,6 +72,21 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "regex:^(?:(?<compatibility>.+?)-)?v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+    },
+    {
+      // internal/test/integration/components/weaver/service.yml is a Compose
+      // service fragment, but its filename doesn't match the docker-compose
+      // manager's compose*.yml pattern, so its digest-pinned image would
+      // otherwise never be updated (it silently lagged a version behind the
+      // other weaver pins). Track it with the same generic image-ref shape used
+      // for the Go files above.
+      "customType": "regex",
+      "managerFilePatterns": ["/^internal\\/test\\/integration\\/components\\/weaver\\/service\\.yml$/"],
+      "matchStrings": [
+        "(?<depName>[a-z0-9][a-z0-9.\\-]*(?:/[a-z0-9][a-z0-9._\\-]*)+):(?<currentValue>[a-zA-Z0-9][a-zA-Z0-9._\\-]*)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "regex:^(?:(?<compatibility>.+?)-)?v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     }
   ],
   "packageRules": [
@@ -433,6 +448,25 @@
       "matchPackageNames": ["org.graalvm.buildtools:native-maven-plugin"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      // Pin every otel/weaver reference to one version in a single PR. The refs
+      // live across four managers: dependencies.Dockerfile (dockerfile — the
+      // image `make lint-schema` reads), the OATS/integration compose fragments
+      // (docker-compose), the Go test pin (custom regex), and service.yml
+      // (custom regex). Without this, each bumps in its own PR on its own
+      // schedule, so lint-schema and the live-check suites validate against
+      // different weaver builds until the last PR merges — the exact drift #2784
+      // caused (it moved only the three compose files). This rule is LAST on
+      // purpose: packageRules resolve last-match-wins, so its groupName and
+      // schedule override the "Docker" and "integration test pinned images"
+      // rules that also match these refs, and enabled:true re-includes the ones
+      // the "internal/test/**" patch/digest disable rule would otherwise drop.
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["otel/weaver"],
+      "groupName": "otel/weaver image",
+      "enabled": true,
+      "schedule": ["before 6am on Tuesday"]
     }
   ],
   "labels": [

--- a/dependencies.Dockerfile
+++ b/dependencies.Dockerfile
@@ -5,4 +5,4 @@ FROM gradle:9.6.1-jdk21-noble@sha256:d3e4ec60a75f6ada80f52e3c648ccfcbeaff4bc0d8e
 FROM ghcr.io/astral-sh/uv:python3.9-trixie-slim@sha256:a383cbce4fff5af7afb904d85bebf0868d0c41d7231dc43a4f0962fb041bbf0f AS python39
 FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim@sha256:2e5867a06156cb8be272125d32fc5032ed750a1268a9350d87a7d322540eb59f AS python314
 FROM golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS golang
-FROM otel/weaver:v0.25.0@sha256:bef6000b4a4be46f81242f9ee785e0ebf0604606c15f92cb54a59893a741ec0c AS weaver
+FROM otel/weaver:v0.25.1@sha256:9ad46ca9cd4fa5974b121f886aa3e9946a8ef8ea905001a96c018d21f9db87ca AS weaver

--- a/internal/test/integration/components/weaver/service.yml
+++ b/internal/test/integration/components/weaver/service.yml
@@ -17,15 +17,13 @@
 # volumes resolve against the file that declares them, so the consuming
 # compose must own its own bind mount or the registry path would be wrong.
 #
-# weaver writes its live-check report to /tmp/weaver-out/live_check.json,
-# bind-mounted to /tmp/obi-weaver-out on the docker host. Test harness reads
-# directly from the host path — docker cp from a stopped container on RHEL
-# overlayfs returned sparse files with mid-stream NUL holes. user: 0 lets
-# the container write into the docker-managed bind mount source regardless
-# of host ownership.
+# weaver runs with `--output http`: the test harness POSTs the admin /stop
+# endpoint and reads the live-check report back from the response body. The
+# `compact` template keeps that body small enough to avoid the truncation that
+# large reports hit when weaver closes the connection on exit.
 services:
   weaver:
-    image: otel/weaver:v0.24.1@sha256:263964a7d444e77812f7a2d654e17683c4760a968c91278acdb7a44c20ccd572
+    image: otel/weaver:v0.25.1@sha256:9ad46ca9cd4fa5974b121f886aa3e9946a8ef8ea905001a96c018d21f9db87ca
     container_name: weaver
     user: "0:0"
     working_dir: /obi-registry
@@ -40,13 +38,13 @@ services:
       - --admin-port
       - "4320"
       - --format
-      - json
+      - compact
+      - --templates
+      - /obi-registry/.live_check_templates
       - --diagnostic-format
       - json
       - --output
-      - /tmp/weaver-out
-    volumes:
-      - /tmp/obi-weaver-out:/tmp/weaver-out
+      - http
     ports:
       - "4320:4320" # admin port (for /stop from test host)
     healthcheck:

--- a/internal/test/integration/dockerutil_test.go
+++ b/internal/test/integration/dockerutil_test.go
@@ -42,7 +42,7 @@ const (
 	// `internal/test/integration/components/weaver/service.yml` so the
 	// programmatic-setup tests run weaver with the same image as the
 	// compose-driven ones.
-	imgWeaver = img.Docker("otel/weaver:v0.25.0@sha256:bef6000b4a4be46f81242f9ee785e0ebf0604606c15f92cb54a59893a741ec0c")
+	imgWeaver = img.Docker("otel/weaver:v0.25.1@sha256:9ad46ca9cd4fa5974b121f886aa3e9946a8ef8ea905001a96c018d21f9db87ca")
 )
 
 // setupDockerNetwork initializes a custom network for the test.
@@ -193,8 +193,7 @@ func setupContainerCollector(t *testing.T, net dockertest.Network, configFile st
 // alongside the otelcol container. Mirrors the shared compose snippet at
 // `components/weaver/service.yml`: same image digest.
 // The container is named exactly "weaver" — matching `weaverContainer` in
-// `weaver.go` — because `runWeaverValidation` `docker wait` / `docker cp`
-// by name.
+// `weaver.go` — because the cleanup path force-removes it by name.
 func setupContainerWeaver(t *testing.T, net dockertest.Network) {
 	t.Helper()
 
@@ -208,13 +207,13 @@ func setupContainerWeaver(t *testing.T, net dockertest.Network) {
 			"--include-unreferenced",
 			"--inactivity-timeout", "300",
 			"--admin-port", "4320",
-			"--format", "json",
+			"--format", "compact",
+			"--templates", "/obi-registry/.live_check_templates",
 			"--diagnostic-format", "json",
-			"--output", "/tmp/weaver-out",
+			"--output", "http",
 		}),
 		dockertest.WithMounts([]string{
 			filepath.Join(pathRoot, "schemas/obi") + ":/obi-registry:ro",
-			"/tmp/obi-weaver-out:/tmp/weaver-out",
 		}),
 		dockertest.WithPortBindings(portBindings("4320/tcp", "4320")),
 		dockertest.WithContainerConfig(func(config *container.Config) {
@@ -227,7 +226,7 @@ func setupContainerWeaver(t *testing.T, net dockertest.Network) {
 	require.NoError(t, err, "could not start weaver container")
 	t.Cleanup(func() {
 		// Best-effort: `runWeaverValidation` may have already removed it via
-		// `docker wait` + `docker rm -f`; ignore the error in that case.
+		// `docker rm -f`; ignore the error in that case.
 		_ = w.Close(context.Background())
 	})
 

--- a/internal/test/integration/weaver.go
+++ b/internal/test/integration/weaver.go
@@ -5,12 +5,15 @@ package integration // import "go.opentelemetry.io/obi/internal/test/integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -18,17 +21,15 @@ import (
 
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 
-	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
 	"go.opentelemetry.io/obi/internal/test/weavercheck"
 )
 
 const (
 	weaverContainer = "weaver"
 	weaverAdminPort = 4320
-	// weaverTimeout bounds the entire post-/stop sequence (HTTP /stop,
-	// docker wait, docker cp of the report file, parse). The drain after
-	// /stop scales with the unique signal count — heavy multi-language
-	// suites need real headroom.
+	// weaverTimeout bounds the /stop request, whose response weaver produces by
+	// building the live-check report — that build scales with the unique signal
+	// count, so heavy multi-language suites need real headroom.
 	weaverTimeout = 3 * time.Minute
 )
 
@@ -59,11 +60,12 @@ func runWeaverValidation(t *testing.T) {
 }
 
 // fetchWeaverReportDocker stops the weaver container (which runs as a service
-// in the Docker Compose stack receiving OTLP from the collector), reads its
-// live-check report from the host bind mount, archives it, and parses it. It
-// returns the parsed report and ok=true on success. On any failure it records
-// the error (or, when a prior test failure is detected, simply tears weaver
-// down so the surrounding compose teardown stays clean) and returns ok=false.
+// in the Docker Compose stack receiving OTLP from the collector) via its admin
+// /stop endpoint, reads the live-check report from the /stop response body
+// (weaver runs with --output http), archives it, and parses it. It returns the
+// parsed report and ok=true on success. On any failure it records the error (or,
+// when a prior test failure is detected, simply tears weaver down so the
+// surrounding compose teardown stays clean) and returns ok=false.
 //
 // This must be called while the Docker Compose stack is still running.
 func fetchWeaverReportDocker(t *testing.T) (*weavercheck.Report, bool) {
@@ -75,54 +77,40 @@ func fetchWeaverReportDocker(t *testing.T) (*weavercheck.Report, bool) {
 			"only stopping the weaver container so compose teardown is clean")
 	}
 
-	// weaver writes the report as root; delete via docker exec, not os.Remove.
-	const hostReport = "/tmp/obi-weaver-out/live_check.json"
-	const containerReport = "/tmp/weaver-out/live_check.json"
-	rmCtx, rmCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer rmCancel()
-	if _, err := docker.Exec(rmCtx, weaverContainer, "rm", "-f", containerReport); err != nil {
-		t.Errorf("removing stale weaver report: %v", err)
-		return nil, false
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), weaverTimeout)
 	defer cancel()
 
-	// Signal weaver to stop accepting data and produce its report. If any
-	// post-/stop step fails (timeout, container already killed, …) we record
-	// the failure and force-remove the container so the surrounding
-	// `compose.Close()` still runs and the next test invocation starts from
-	// a clean slate.
+	// POST /stop makes weaver finalize its live-check, return the report in the
+	// response body, and exit. On any failure we record it and force-remove the
+	// container so the surrounding `compose.Close()` still runs and the next
+	// test invocation starts from a clean slate.
 	url := fmt.Sprintf("http://127.0.0.1:%d/stop", weaverAdminPort)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Errorf("failed to stop weaver (is it running?): %v", err)
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			t.Errorf("failed to stop weaver (is it running?): %v", err)
+		} else {
+			t.Errorf("posting weaver /stop: %v", err)
+		}
 		forceRemoveWeaverContainer(t)
 		return nil, false
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
 		t.Errorf("weaver /stop returned HTTP %d", resp.StatusCode)
 		forceRemoveWeaverContainer(t)
 		return nil, false
 	}
-
-	// Wait for the weaver container to finish processing and exit.
-	if _, err = exec.CommandContext(ctx, "docker", "wait", weaverContainer).Output(); err != nil {
-		t.Errorf("failed to wait for weaver container: %v", err)
+	rawReport, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("failed to read weaver /stop response body: %v", err)
 		forceRemoveWeaverContainer(t)
 		return nil, false
 	}
 
 	if priorFailure {
-		return nil, false
-	}
-
-	rawReport, err := os.ReadFile(hostReport)
-	if err != nil {
-		t.Errorf("failed to read weaver report at %s: %v", hostReport, err)
 		return nil, false
 	}
 	return archiveAndParseWeaverReport(t, rawReport)
@@ -150,11 +138,11 @@ func archiveAndParseWeaverReport(t *testing.T, rawReport []byte) (*weavercheck.R
 	return report, true
 }
 
-// forceRemoveWeaverContainer is the best-effort cleanup we use when the normal
-// /stop + docker-wait sequence couldn't finish. Without this, a stuck or
-// killed weaver container survives the failed test invocation and the next
-// run hits "container name already in use" (or, worse, a half-broken admin
-// port that returns "connection reset by peer").
+// forceRemoveWeaverContainer is the best-effort cleanup we use when the /stop
+// request or report read couldn't finish. Without this, a stuck or killed
+// weaver container survives the failed test invocation and the next run hits
+// "container name already in use" (or, worse, a half-broken admin port that
+// returns "connection reset by peer").
 func forceRemoveWeaverContainer(t *testing.T) {
 	t.Helper()
 	rmCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/test/oats/amqp/docker-compose-obi-java-amqp.yml
+++ b/internal/test/oats/amqp/docker-compose-obi-java-amqp.yml
@@ -81,7 +81,7 @@ services:
   # weaver's OTLP listener is moved to 4327; admin /stop stays on 4320. The OATS
   # harness stops it after the checks and fails the test on any actionable advisory.
   weaver:
-    image: otel/weaver:v0.25.0@sha256:bef6000b4a4be46f81242f9ee785e0ebf0604606c15f92cb54a59893a741ec0c
+    image: otel/weaver:v0.25.1@sha256:9ad46ca9cd4fa5974b121f886aa3e9946a8ef8ea905001a96c018d21f9db87ca
     network_mode: host
     user: "0:0"
     working_dir: /obi-registry
@@ -98,14 +98,15 @@ services:
       - --admin-port
       - "4320"
       - --format
-      - json
+      - compact
+      - --templates
+      - /obi-registry/.live_check_templates
       - --diagnostic-format
       - json
       - --output
-      - /tmp/weaver-out
+      - http
     volumes:
       - ../../../../schemas/obi:/obi-registry:ro
-      - /tmp/obi-weaver-out:/tmp/weaver-out
     healthcheck:
       test: ["CMD-SHELL", "wget --timeout=1 -q -O /dev/null http://127.0.0.1:4327/ 2>&1 | grep -qv refused"]
       interval: 5s

--- a/internal/test/oats/amqp/docker-compose-obi-python-amqp.yml
+++ b/internal/test/oats/amqp/docker-compose-obi-python-amqp.yml
@@ -79,7 +79,7 @@ services:
   # weaver's OTLP listener is moved to 4327; admin /stop stays on 4320. The OATS
   # harness stops it after the checks and fails the test on any actionable advisory.
   weaver:
-    image: otel/weaver:v0.25.0@sha256:bef6000b4a4be46f81242f9ee785e0ebf0604606c15f92cb54a59893a741ec0c
+    image: otel/weaver:v0.25.1@sha256:9ad46ca9cd4fa5974b121f886aa3e9946a8ef8ea905001a96c018d21f9db87ca
     network_mode: host
     user: "0:0"
     working_dir: /obi-registry
@@ -96,14 +96,15 @@ services:
       - --admin-port
       - "4320"
       - --format
-      - json
+      - compact
+      - --templates
+      - /obi-registry/.live_check_templates
       - --diagnostic-format
       - json
       - --output
-      - /tmp/weaver-out
+      - http
     volumes:
       - ../../../../schemas/obi:/obi-registry:ro
-      - /tmp/obi-weaver-out:/tmp/weaver-out
     healthcheck:
       test: ["CMD-SHELL", "wget --timeout=1 -q -O /dev/null http://127.0.0.1:4327/ 2>&1 | grep -qv refused"]
       interval: 5s

--- a/internal/test/oats/harness/weaver.go
+++ b/internal/test/oats/harness/weaver.go
@@ -18,13 +18,12 @@ import (
 
 const (
 	// weaverAdminURL is where a weaver-wired OATS group publishes weaver's admin
-	// /stop endpoint on the test host; weaverReportPath is the host path weaver
-	// writes its live-check report to. Every group is expected to wire weaver
-	// (append `weaver/docker-compose-weaver.yml` to the test case's compose file
-	// list); an unreachable admin port fails the spec so a new group can't
+	// /stop endpoint on the test host; the POST both stops weaver and returns its
+	// live-check report in the response body. Every group is expected to wire
+	// weaver (append `weaver/docker-compose-weaver.yml` to the test case's compose
+	// file list); an unreachable admin port fails the spec so a new group can't
 	// silently skip semantic-convention validation.
-	weaverAdminURL   = "http://localhost:4320/stop"
-	weaverReportPath = "/tmp/obi-weaver-out/live_check.json"
+	weaverAdminURL = "http://localhost:4320/stop"
 
 	// skipWeaverEnv opts a run out of weaver validation entirely — intended
 	// only for local debugging of a compose setup, never for CI.
@@ -38,7 +37,7 @@ const (
 // shared weaver compose fragment), unless the run explicitly opts out via
 // TESTCASE_SKIP_WEAVER=true.
 func validateWeaver() {
-	if os.Getenv(skipWeaverEnv) == "true" || true {
+	if os.Getenv(skipWeaverEnv) == "true" {
 		ginkgo.GinkgoWriter.Printf("%s=true — skipping weaver validation\n", skipWeaverEnv)
 		return
 	}
@@ -46,7 +45,7 @@ func validateWeaver() {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	report, err := weavercheck.FetchReport(ctx, weaverAdminURL, weaverReportPath)
+	report, err := weavercheck.FetchReport(ctx, weaverAdminURL)
 	if err != nil {
 		if errors.Is(err, syscall.ECONNREFUSED) {
 			ginkgo.Fail(fmt.Sprintf(

--- a/internal/test/oats/weaver/docker-compose-weaver.yml
+++ b/internal/test/oats/weaver/docker-compose-weaver.yml
@@ -24,7 +24,7 @@ services:
   # admin port after the per-test checks and fails the test on any actionable
   # advisory.
   weaver:
-    image: otel/weaver:v0.25.0@sha256:bef6000b4a4be46f81242f9ee785e0ebf0604606c15f92cb54a59893a741ec0c
+    image: otel/weaver:v0.25.1@sha256:9ad46ca9cd4fa5974b121f886aa3e9946a8ef8ea905001a96c018d21f9db87ca
     user: "0:0"
     working_dir: /obi-registry
     command:
@@ -38,14 +38,15 @@ services:
       - --admin-port
       - "4320"
       - --format
-      - json
+      - compact
+      - --templates
+      - /obi-registry/.live_check_templates
       - --diagnostic-format
       - json
       - --output
-      - /tmp/weaver-out
+      - http
     volumes:
       - ../../../../schemas/obi:/obi-registry:ro
-      - /tmp/obi-weaver-out:/tmp/weaver-out
     ports:
       - "4320:4320" # admin port (for /stop from the test host)
     healthcheck:

--- a/internal/test/weavercheck/weavercheck.go
+++ b/internal/test/weavercheck/weavercheck.go
@@ -2,17 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package weavercheck holds the transport-agnostic parsing and validation of
-// the OpenTelemetry weaver live-check report. Both the Docker-Compose
-// integration suites (package integration) and the Kubernetes / kind suites
-// (package kube) feed weaver the same OTLP stream and read back the same JSON
-// report; this package owns the shared report schema, the ignore lists, and
-// the advisory-accounting + assertion logic so the two transports stay in
-// lockstep.
+// the OpenTelemetry weaver live-check report. The Docker-Compose integration
+// suites (package integration) and the OATS suites feed weaver the same OTLP
+// stream and read back the same JSON report; this package owns the shared
+// report schema and the assertion logic so the transports stay in lockstep.
 //
-// The transports differ only in HOW they stop weaver and obtain the raw
-// report bytes (docker exec + host bind mount vs. HTTP /stop on a kind host
-// port + the shared testoutput mount); everything from "parse the bytes" on
-// is here.
+// Weaver runs with `--output http` and the `compact` output template;
+// FetchReport POSTs the admin `/stop` endpoint and reads the report back from
+// the response body (kept small enough by the template to avoid truncation).
+// Which advisories are suppressed (the accepted `server`/`client`/`iface`
+// namespace collisions) and which information-level advice is promoted to a
+// failure (`extends_namespace`, `undefined_enum_variant`) is declared in
+// `schemas/obi/.weaver.toml` via `[[live-check.finding_filters]]` and
+// `[[live-check.finding_level_overrides]]`, so weaver applies both before the
+// report reaches this package. What remains here is a single rule: fail on any
+// `violation`-level advisory.
 package weavercheck // import "go.opentelemetry.io/obi/internal/test/weavercheck"
 
 import (
@@ -20,19 +24,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
-	"time"
+	"syscall"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestingT is the minimal test-reporter interface Validate needs. Both
-// *testing.T (the Docker and Kubernetes suites) and ginkgo.GinkgoT() (the OATS
-// suites) satisfy it, so the exact same enforce logic runs across every
+// *testing.T (the Docker-Compose integration suites) and ginkgo.GinkgoT() (the
+// OATS suites) satisfy it, so the exact same enforce logic runs across every
 // transport rather than being reimplemented per suite.
 type TestingT interface {
 	Helper()
@@ -41,83 +45,26 @@ type TestingT interface {
 	FailNow()
 }
 
-// IgnoredSignals is an escape hatch for advice we explicitly suppress without
-// declaring the underlying signal in the OBI registry. The harness fails on
-// `violation`-level advice AND on `extends_namespace` advice (an attribute
-// emitted under an existing semconv namespace but not declared in any
-// registry). Most non-semconv emissions (Prometheus `target_info`,
-// OTel-contrib spanmetrics / service-graph shape, OBI-internal markers) are
-// declared in `schemas/obi/` and validated against by weaver, so this map is
-// intended to stay small. Add entries here only as a short-lived bridge while
-// OBI catches up to a semconv contract. Keys are "signal_type:signal_name".
-var IgnoredSignals = map[string]struct{}{}
-
-// IgnoredAdviceMessages suppresses specific advice messages that match known
-// structural tensions weaver reports against the registry as a whole rather
-// than against any one signal. Today this only covers the `server` / `client`
-// namespace collision: the OTel collector-contrib `servicegraphconnector`
-// emits bare `server` / `client` labels (matched in `service_graph.yaml`), but
-// upstream semconv reserves `server.*` / `client.*` as namespace prefixes
-// (`server.address`, `server.port`, …). Weaver's lint flags the registry-level
-// collision on every signal that touches an upstream `server.*` / `client.*`
-// attribute, even ones that don't use the bare label. The contract OBI emits
-// is fixed by the connector convention; the ignore documents the tension.
-var IgnoredAdviceMessages = map[string]struct{}{
-	"Namespace 'server' collides with existing attribute 'server.address'": {},
-	"Namespace 'server' collides with existing attribute 'server.port'":    {},
-	"Namespace 'client' collides with existing attribute 'client.address'": {},
-	"Namespace 'client' collides with existing attribute 'client.port'":    {},
-	// OBI emits `iface` (interface name) alongside `iface.direction`, so
-	// `iface` is both a leaf attribute *and* the namespace of another. The
-	// emission contract is owned by netolly, mirrors the older network-flow
-	// exporter convention, and is not negotiable for backward compatibility —
-	// accept the structural warning.
-	"Namespace 'iface' collides with existing attribute 'iface.direction'": {},
-}
-
-// Weaver finding-type identifiers (from weaver's rego policy output) that
-// OBI's enforcement logic matches on.
-//
-// NOTE: these strings come from weaver's rego policy output. If a weaver
-// version bump renames them, enforcement silently weakens — re-verify when
-// bumping the pinned weaver image.
-const (
-	adviceTypeExtendsNamespace     = "extends_namespace"
-	adviceTypeUndefinedEnumVariant = "undefined_enum_variant"
-)
-
-// actionableAdviceTypes lists the weaver finding-type values OBI treats as
-// failures in addition to `violation`-level advice. Hoisted here (rather than
-// matched as an inline string literal) so the coupling to weaver's advice-type
-// vocabulary lives in one documented place and is easy to extend.
-//
-//   - extends_namespace: an attribute emitted under an existing semconv
-//     namespace but declared in no registry (upstream semconv or
-//     `schemas/obi/`). Weaver classifies these as `information`-level, so
-//     without this they would silently pass; OBI requires every emitted
-//     attribute to be declared.
-//
-//   - undefined_enum_variant: an enumerated attribute emitted with a value
-//     outside the members declared for it in the registry (e.g. an empty
-//     string for `messaging.operation.type`, or an HTTP status code leaking
-//     into a gRPC status attribute). Weaver classifies these as
-//     `information`-level because enums are open; OBI treats them as emitter
-//     bugs — when OBI has no valid value for an enumerated attribute it must
-//     omit the attribute instead. Values OBI intentionally emits beyond the
-//     pinned upstream members are declared in the registry override groups
-//     under `schemas/obi/groups/` (closed enums gain the extra members;
-//     attributes whose value space is open-ended are re-typed as strings —
-//     see schemas/obi/README.md), so weaver itself accepts them and this
-//     check stays a pure bug detector.
-var actionableAdviceTypes = map[string]struct{}{
-	adviceTypeExtendsNamespace:     {},
-	adviceTypeUndefinedEnumVariant: {},
-}
-
-// Report is the top-level JSON structure emitted by weaver with --format json.
+// Report is the top-level JSON structure emitted by weaver's `compact`
+// live-check template: the statistics block plus a deduplicated findings list.
+// The per-sample bodies weaver's builtin `--format json` would emit (attribute
+// values, exemplars, data points) are dropped, and the advisories are collapsed
+// by message, keeping the report small while preserving every finding's level
+// and the signals that triggered it.
 type Report struct {
-	Samples    []json.RawMessage `json:"samples"`
-	Statistics Statistics        `json:"statistics"`
+	Findings   []Finding  `json:"findings"`
+	Statistics Statistics `json:"statistics"`
+}
+
+// Finding is one deduplicated advisory: a message reported at a given level and
+// advice type, how many times it occurred, and the distinct signals
+// (`<signal_type>:<signal_name>`) that triggered it.
+type Finding struct {
+	Message string   `json:"message"`
+	Level   string   `json:"level"`
+	Type    string   `json:"type"`
+	Count   int      `json:"count"`
+	Signals []string `json:"signals"`
 }
 
 type Statistics struct {
@@ -125,28 +72,7 @@ type Statistics struct {
 	TotalEntitiesByType map[string]int `json:"total_entities_by_type"`
 	TotalAdvisories     int            `json:"total_advisories"`
 	AdviceLevelCounts   map[string]int `json:"advice_level_counts"`
-	AdviceTypeCounts    map[string]int `json:"advice_type_counts"`
-	AdviceMessageCounts map[string]int `json:"advice_message_counts"`
 	RegistryCoverage    float64        `json:"registry_coverage"`
-}
-
-// Advice represents a single advisory finding from the weaver report.
-type Advice struct {
-	Message    string `json:"message"`
-	Level      string `json:"level"`
-	AdviceType string `json:"id"`
-	SignalType string `json:"signal_type"`
-	SignalName string `json:"signal_name"`
-}
-
-type liveCheckResult struct {
-	AllAdvice []Advice `json:"all_advice"`
-}
-
-type adviceInfo struct {
-	Level      string
-	AdviceType string
-	Signals    map[string]struct{} // set of "signal_type:signal_name"
 }
 
 // Parse unmarshals a raw weaver JSON report.
@@ -162,300 +88,94 @@ func Parse(rawReport []byte) (*Report, error) {
 }
 
 // FetchReport stops the weaver live-check container via its admin /stop
-// endpoint and returns the parsed report once weaver has flushed it to
-// reportPath. It is transport-agnostic and logging-agnostic (returns an error
-// rather than failing a test), so any transport that publishes weaver's admin
-// port to the host and mounts its report file can reuse it.
-func FetchReport(ctx context.Context, adminURL, reportPath string) (*Report, error) {
-	// A previous test in the same process may have left an older report at
-	// reportPath (weaver writes it as root, so we can't delete it here).
-	// Snapshot its mtime so waitForReport only accepts a report written
-	// after this /stop.
-	var prevMod time.Time
-	if fi, err := os.Stat(reportPath); err == nil {
-		prevMod = fi.ModTime()
-	}
-
+// endpoint and returns the parsed report from the /stop response body (weaver
+// runs with `--output http`). The `compact` template keeps that body small
+// enough to clear the socket buffer before weaver exits, so the response is not
+// truncated. A refused connection (weaver never came up / admin port unmapped)
+// is reported distinctly so callers can hint at a mis-wired stack. It is
+// transport-agnostic and logging-agnostic (returns an error rather than failing
+// a test).
+func FetchReport(ctx context.Context, adminURL string) (*Report, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, adminURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("building weaver /stop request: %w", err)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("stopping weaver (is it running and the admin port mapped?): %w", err)
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			return nil, fmt.Errorf("stopping weaver (is it running and the admin port mapped?): %w", err)
+		}
+		return nil, fmt.Errorf("posting weaver /stop: %w", err)
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("weaver /stop returned HTTP %d", resp.StatusCode)
 	}
-	raw, err := waitForReport(ctx, reportPath, prevMod)
+	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading weaver /stop response body: %w", err)
 	}
 	return Parse(raw)
 }
 
-// waitForReport polls reportPath until it holds a report newer than prevMod,
-// is non-empty, and its size is stable across two ticks — so neither a stale
-// report from an earlier test nor a still-flushing one is read — or ctx
-// expires.
-func waitForReport(ctx context.Context, reportPath string, prevMod time.Time) ([]byte, error) {
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-	var lastSize int64 = -1
-	for {
-		if fi, err := os.Stat(reportPath); err == nil && fi.Size() > 0 && fi.ModTime().After(prevMod) {
-			if fi.Size() == lastSize {
-				return os.ReadFile(reportPath)
-			}
-			lastSize = fi.Size()
-		}
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("weaver report %s not ready: %w", reportPath, ctx.Err())
-		case <-ticker.C:
-		}
-	}
-}
-
-// Validate logs the full advisory breakdown and asserts that zero actionable
-// advisories remain. An advisory is actionable when it is `violation`-level OR
-// its advice_type is in actionableAdviceTypes, after applying the ignore lists.
-// It always enforces: if weaver found actionable advisories, the test fails.
+// Validate logs the full advisory breakdown and asserts that weaver reported no
+// `violation`-level advisory. Suppression of the accepted namespace collisions
+// and promotion of `extends_namespace` / `undefined_enum_variant` to
+// `violation` are configured in `schemas/obi/.weaver.toml`, so the level counts
+// weaver reports here already reflect them; enforcement is simply "zero
+// violations".
 func Validate(t TestingT, report *Report) {
 	t.Helper()
 
 	stats := &report.Statistics
 
-	// Weaver must have received telemetry data.
-	require.NotEmptyf(t, report.Samples,
-		"weaver received no samples — OTLP data did not reach weaver")
+	// Weaver must have received telemetry data. The `compact` report drops the
+	// per-sample bodies, so assert on the entity count rather than sample count.
+	require.Positivef(t, stats.TotalEntities,
+		"weaver received no telemetry — OTLP data did not reach weaver")
 
 	violations := stats.AdviceLevelCounts["violation"]
 
 	t.Logf("weaver statistics:")
 	t.Logf("  total entities:   %d", stats.TotalEntities)
-	for typ, count := range stats.TotalEntitiesByType {
-		t.Logf("    %-15s %d", typ, count)
+	for _, typ := range sortedKeys(stats.TotalEntitiesByType) {
+		t.Logf("    %-15s %d", typ, stats.TotalEntitiesByType[typ])
 	}
 	t.Logf("  total advisories: %d", stats.TotalAdvisories)
-	for level, count := range stats.AdviceLevelCounts {
-		t.Logf("    %-15s %d", level, count)
+	for _, level := range sortedKeys(stats.AdviceLevelCounts) {
+		t.Logf("    %-15s %d", level, stats.AdviceLevelCounts[level])
 	}
 	t.Logf("  registry coverage: %.1f%%", stats.RegistryCoverage*100)
 
-	// Build message → {level, type, signals} lookup from the sample data.
-	adviceByMsg := collectAdviceInfo(report.Samples)
-
-	// Surface the advisories that actually fail the check first, so the cause
-	// of a failure is obvious without scanning the full advisory dump below.
-	actionable := collectActionableAdvisories(stats, adviceByMsg)
-	actionableAdvisories := 0
-	for _, e := range actionable {
-		actionableAdvisories += e.Occurrences
-	}
-	if len(actionable) > 0 {
-		t.Logf("  actionable advisories:")
-		for _, e := range actionable {
-			signals := "unknown"
-			if len(e.Signals) > 0 {
-				signals = strings.Join(e.Signals, ", ")
+	// Surface the violation-level advisories first so the cause of a failure is
+	// obvious, then log every finding grouped by level. Findings arrive sorted
+	// by message (weaver's group_by), so the output is stable.
+	if violations > 0 {
+		t.Logf("  violation advisories:")
+		for i := range report.Findings {
+			if f := &report.Findings[i]; f.Level == "violation" {
+				t.Logf("    [%dx] %s (signals: %s)", f.Count, f.Message, strings.Join(f.Signals, ", "))
 			}
-			t.Logf("    [%s/%s] [%dx] %s (signals: %s)", e.Level, e.AdviceType, e.Occurrences, e.Message, signals)
 		}
 	}
-
-	// Log all advisory messages grouped by level for full context.
 	t.Logf("  advisory details:")
 	for _, level := range []string{"violation", "improvement", "information"} {
-		for msg, count := range stats.AdviceMessageCounts {
-			_, msgIgnored := IgnoredAdviceMessages[msg]
-			info := adviceByMsg[msg]
-			if info == nil {
-				if level != "violation" {
-					continue
-				}
-
-				suffix := ""
-				if msgIgnored {
-					suffix = " [ignored]"
-				}
-				t.Logf("    [%s] [%dx] %s (signals: unknown)%s", level, count, msg, suffix)
-				continue
-			}
-			if info.Level != level {
-				continue
-			}
-			signals := sortedSignals(info.Signals)
-			suffix := ""
-			if msgIgnored || allSignalsIgnored(info.Signals) {
-				suffix = " [ignored]"
-			}
-			t.Logf("    [%s] [%dx] %s (signals: %s)%s", level, count, msg, strings.Join(signals, ", "), suffix)
-		}
-	}
-
-	t.Logf("  advisories: %d violation(s), %d actionable (violations + actionableAdviceTypes, after ignoring %v)",
-		violations, actionableAdvisories, sortedSignals(IgnoredSignals))
-
-	assert.Zero(t, actionableAdvisories,
-		"weaver found %d actionable semantic convention advisory(ies) "+
-			"(violations or undeclared attributes under existing semconv namespaces)", actionableAdvisories)
-}
-
-// isActionableAdvice reports whether an advisory must fail validation:
-// `violation`-level advice always is, and so is any advice type listed in
-// actionableAdviceTypes (e.g. `extends_namespace`, which weaver classifies as
-// information-level).
-func isActionableAdvice(info *adviceInfo) bool {
-	if info.Level == "violation" {
-		return true
-	}
-
-	_, actionable := actionableAdviceTypes[info.AdviceType]
-	return actionable
-}
-
-// actionableEntry is a single advisory that fails validation, carrying the
-// attribution needed to print an at-a-glance "this is what broke" summary.
-type actionableEntry struct {
-	Message     string
-	Level       string
-	AdviceType  string
-	Occurrences int
-	Signals     []string
-}
-
-// collectActionableAdvisories returns the advisories that must fail validation,
-// excluding signals listed in IgnoredSignals and messages listed in
-// IgnoredAdviceMessages. Messages present in the statistics but absent from
-// the sample data carry no level/type/signal attribution, so they are
-// conservatively treated as actionable unless message-ignored. Results are
-// sorted by descending occurrence count, then message, for stable output.
-func collectActionableAdvisories(stats *Statistics, adviceByMsg map[string]*adviceInfo) []actionableEntry {
-	var entries []actionableEntry
-	for msg, occurrences := range stats.AdviceMessageCounts {
-		_, messageIgnored := IgnoredAdviceMessages[msg]
-		info := adviceByMsg[msg]
-		if info == nil {
-			if !messageIgnored {
-				entries = append(entries, actionableEntry{
-					Message:     msg,
-					Level:       "unknown",
-					AdviceType:  "unknown",
-					Occurrences: occurrences,
-				})
-			}
-			continue
-		}
-		ignored := messageIgnored || allSignalsIgnored(info.Signals)
-		if isActionableAdvice(info) && !ignored {
-			entries = append(entries, actionableEntry{
-				Message:     msg,
-				Level:       info.Level,
-				AdviceType:  info.AdviceType,
-				Occurrences: occurrences,
-				Signals:     sortedSignals(info.Signals),
-			})
-		}
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].Occurrences != entries[j].Occurrences {
-			return entries[i].Occurrences > entries[j].Occurrences
-		}
-		return entries[i].Message < entries[j].Message
-	})
-	return entries
-}
-
-// countActionableAdvisories counts advisories that must fail validation.
-func countActionableAdvisories(stats *Statistics, adviceByMsg map[string]*adviceInfo) int {
-	var count int
-	for _, e := range collectActionableAdvisories(stats, adviceByMsg) {
-		count += e.Occurrences
-	}
-	return count
-}
-
-// collectAdviceInfo scans all weaver samples to build a complete map from
-// advisory message to its severity level, advice type, and the set of signals
-// that triggered it.
-func collectAdviceInfo(samples []json.RawMessage) map[string]*adviceInfo {
-	result := make(map[string]*adviceInfo)
-
-	for _, raw := range samples {
-		var generic map[string]json.RawMessage
-		if json.Unmarshal(raw, &generic) != nil {
-			continue
-		}
-		for _, v := range generic {
-			extractAdviceInfo(v, result)
-		}
-	}
-
-	return result
-}
-
-// extractAdviceInfo recursively walks JSON looking for all_advice arrays and
-// records message → {level, type, signals} mappings.
-func extractAdviceInfo(data json.RawMessage, result map[string]*adviceInfo) {
-	// Try as object with live_check_result or nested fields.
-	var obj map[string]json.RawMessage
-	if json.Unmarshal(data, &obj) == nil {
-		if lcr, ok := obj["live_check_result"]; ok {
-			var checkResult liveCheckResult
-			if json.Unmarshal(lcr, &checkResult) == nil {
-				for i := range checkResult.AllAdvice {
-					a := &checkResult.AllAdvice[i]
-					info, exists := result[a.Message]
-					if !exists {
-						info = &adviceInfo{
-							Level:      a.Level,
-							AdviceType: a.AdviceType,
-							Signals:    make(map[string]struct{}),
-						}
-						result[a.Message] = info
-					}
-					if a.SignalName != "" {
-						sig := a.SignalType + ":" + a.SignalName
-						info.Signals[sig] = struct{}{}
-					}
-				}
+		for i := range report.Findings {
+			if f := &report.Findings[i]; f.Level == level {
+				t.Logf("    [%s] [%dx] %s (signals: %s)", f.Level, f.Count, f.Message, strings.Join(f.Signals, ", "))
 			}
 		}
-		// Recurse into all values.
-		for _, v := range obj {
-			extractAdviceInfo(v, result)
-		}
-		return
 	}
 
-	// Try as array.
-	var arr []json.RawMessage
-	if json.Unmarshal(data, &arr) == nil {
-		for _, item := range arr {
-			extractAdviceInfo(item, result)
-		}
-	}
+	assert.Zero(t, violations,
+		"weaver found %d violation-level semantic convention advisory(ies)", violations)
 }
 
-// allSignalsIgnored returns true if every signal in the set is in IgnoredSignals.
-func allSignalsIgnored(signals map[string]struct{}) bool {
-	if len(signals) == 0 {
-		return false
-	}
-	for sig := range signals {
-		if _, ignored := IgnoredSignals[sig]; !ignored {
-			return false
-		}
-	}
-	return true
-}
-
-func sortedSignals(set map[string]struct{}) []string {
-	out := make([]string, 0, len(set))
-	for s := range set {
-		out = append(out, s)
+// sortedKeys returns a count map's keys in lexical order, for stable log output.
+func sortedKeys(m map[string]int) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
 	}
 	sort.Strings(out)
 	return out

--- a/internal/test/weavercheck/weavercheck_test.go
+++ b/internal/test/weavercheck/weavercheck_test.go
@@ -4,129 +4,69 @@
 package weavercheck
 
 import (
-	"encoding/json"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
-// TestExtendsNamespaceAdviceIsActionable exercises weaver's serialized
-// finding ID so information-level namespace extensions cannot silently
-// bypass semantic convention validation.
-func TestExtendsNamespaceAdviceIsActionable(t *testing.T) {
-	const message = "Attribute 'http.custom' extends an existing namespace"
+// recorder is a minimal TestingT that records whether Validate reported a
+// failure, without aborting the enclosing test.
+type recorder struct{ failed bool }
 
-	report := Report{
-		Samples: []json.RawMessage{json.RawMessage(`{
-			"span": {
-				"live_check_result": {
-					"all_advice": [{
-						"id": "extends_namespace",
-						"message": "Attribute 'http.custom' extends an existing namespace",
-						"level": "information",
-						"signal_type": "span",
-						"signal_name": "GET /test"
-					}]
-				}
-			}
-		}`)},
+func (r *recorder) Helper()               {}
+func (r *recorder) Logf(string, ...any)   {}
+func (r *recorder) Errorf(string, ...any) { r.failed = true }
+func (r *recorder) FailNow()              { r.failed = true }
+
+// findingReport mirrors the `compact` template output: a statistics block with
+// a positive entity count plus one deduplicated finding. Validate keys off the
+// statistics for pass/fail and the findings for the logged detail.
+func findingReport(id, level string) Report {
+	return Report{
+		Findings: []Finding{{
+			Message: "advice " + id,
+			Level:   level,
+			Type:    id,
+			Count:   1,
+			Signals: []string{"span:GET /test"},
+		}},
 		Statistics: Statistics{
-			AdviceMessageCounts: map[string]int{message: 1},
+			TotalEntities:     1,
+			AdviceLevelCounts: map[string]int{level: 1},
 		},
 	}
-
-	adviceByMsg := collectAdviceInfo(report.Samples)
-	require.Equal(t, 1, countActionableAdvisories(&report.Statistics, adviceByMsg))
 }
 
-// TestUndefinedEnumVariantAdviceIsActionable exercises weaver's serialized
-// finding ID so information-level out-of-enum values (e.g. an empty
-// messaging.operation.type or an HTTP status leaking into a gRPC status
-// attribute) cannot silently bypass semantic convention validation.
-func TestUndefinedEnumVariantAdviceIsActionable(t *testing.T) {
-	const message = "Enum value '200' is not defined in the registry"
-
-	report := Report{
-		Samples: []json.RawMessage{json.RawMessage(`{
-			"span": {
-				"live_check_result": {
-					"all_advice": [{
-						"id": "undefined_enum_variant",
-						"message": "Enum value '200' is not defined in the registry",
-						"level": "information",
-						"signal_type": "span",
-						"signal_name": "routeguide.RouteGuide/GetFeature"
-					}]
-				}
-			}
-		}`)},
-		Statistics: Statistics{
-			AdviceMessageCounts: map[string]int{message: 1},
-		},
+// TestValidateFailsOnViolation pins that a violation-level advisory (e.g. an
+// undefined_enum_variant that schemas/obi/.weaver.toml promotes to violation)
+// fails validation.
+func TestValidateFailsOnViolation(t *testing.T) {
+	report := findingReport("undefined_enum_variant", "violation")
+	rec := &recorder{}
+	Validate(rec, &report)
+	if !rec.failed {
+		t.Fatal("expected Validate to fail on a violation-level advisory")
 	}
-
-	adviceByMsg := collectAdviceInfo(report.Samples)
-	require.Equal(t, 1, countActionableAdvisories(&report.Statistics, adviceByMsg))
 }
 
-// TestUndefinedEnumVariantEmptyValueIsActionable pins that an empty value on
-// an enumerated attribute — always an emitter bug (the attribute must be
-// omitted instead) — fails validation. Values OBI emits on purpose are
-// declared in the registry override groups under schemas/obi/groups/ (see
-// schemas/obi/README.md), so weaver itself accepts them and no finding is
-// produced; anything weaver still flags is a bug by definition.
-func TestUndefinedEnumVariantEmptyValueIsActionable(t *testing.T) {
-	const message = "Enum attribute 'messaging.operation.type' has value '' which is not documented."
-
-	report := Report{
-		Samples: []json.RawMessage{json.RawMessage(`{
-			"span": {
-				"live_check_result": {
-					"all_advice": [{
-						"id": "undefined_enum_variant",
-						"message": "Enum attribute 'messaging.operation.type' has value '' which is not documented.",
-						"level": "information",
-						"signal_type": "span",
-						"signal_name": "publish"
-					}]
-				}
-			}
-		}`)},
-		Statistics: Statistics{
-			AdviceMessageCounts: map[string]int{message: 2},
-		},
+// TestValidatePassesWithoutViolations pins the inverse: information- and
+// improvement-level advice (which .weaver.toml did not promote) does not fail
+// validation — the harness no longer promotes advice types itself.
+func TestValidatePassesWithoutViolations(t *testing.T) {
+	for _, level := range []string{"information", "improvement"} {
+		report := findingReport("deprecated", level)
+		rec := &recorder{}
+		Validate(rec, &report)
+		if rec.failed {
+			t.Fatalf("expected Validate to pass on %s-level advice", level)
+		}
 	}
-
-	adviceByMsg := collectAdviceInfo(report.Samples)
-	require.Equal(t, 2, countActionableAdvisories(&report.Statistics, adviceByMsg),
-		"empty enum values are emitter bugs and must stay actionable")
 }
 
-// TestInformationAdviceWithoutActionableTypeIsNotCounted pins the inverse:
-// information-level advice whose type is not in actionableAdviceTypes must
-// not fail validation.
-func TestInformationAdviceWithoutActionableTypeIsNotCounted(t *testing.T) {
-	const message = "Attribute 'http.request.method' is deprecated, use ..."
-
-	report := Report{
-		Samples: []json.RawMessage{json.RawMessage(`{
-			"span": {
-				"live_check_result": {
-					"all_advice": [{
-						"id": "deprecated",
-						"message": "Attribute 'http.request.method' is deprecated, use ...",
-						"level": "information",
-						"signal_type": "span",
-						"signal_name": "GET /test"
-					}]
-				}
-			}
-		}`)},
-		Statistics: Statistics{
-			AdviceMessageCounts: map[string]int{message: 1},
-		},
+// TestValidateFailsOnNoTelemetry pins that an empty report — OTLP never reached
+// weaver, so no entities were seen — is a failure rather than a silent pass.
+func TestValidateFailsOnNoTelemetry(t *testing.T) {
+	rec := &recorder{}
+	Validate(rec, &Report{})
+	if !rec.failed {
+		t.Fatal("expected Validate to fail when weaver received no telemetry")
 	}
-
-	adviceByMsg := collectAdviceInfo(report.Samples)
-	require.Equal(t, 0, countActionableAdvisories(&report.Statistics, adviceByMsg))
 }

--- a/schemas/obi/.live_check_templates/compact/report.json.j2
+++ b/schemas/obi/.live_check_templates/compact/report.json.j2
@@ -1,0 +1,1 @@
+{{ ctx | tojson }}

--- a/schemas/obi/.live_check_templates/compact/weaver.yaml
+++ b/schemas/obi/.live_check_templates/compact/weaver.yaml
@@ -1,0 +1,29 @@
+# `compact` live-check output format: the statistics block plus a deduplicated
+# list of findings (message, level, advice type, occurrence count, and the
+# distinct signals that triggered it) — the same detail the harness logs, but
+# collapsed.
+#
+# Must be a hidden directory: a
+# visible weaver.yaml inside the registry mount is parsed as a registry file
+# and rejected.
+whitespace_control:
+  trim_blocks: true
+  lstrip_blocks: true
+
+templates:
+  - template: report.json.j2
+    filter: >
+      { statistics: .statistics,
+        findings: (
+          [ .samples[] | .. | objects | select(has("all_advice")) | .all_advice[] ]
+          | group_by(.message)
+          | map({
+              message: .[0].message,
+              level:   .[0].level,
+              type:    .[0].id,
+              count:   length,
+              signals: ([ .[] | select((.signal_name // "") != "") | "\(.signal_type):\(.signal_name)" ] | unique)
+            })
+        ) }
+    application_mode: single
+    file_name: live_check.json

--- a/schemas/obi/.weaver.toml
+++ b/schemas/obi/.weaver.toml
@@ -1,0 +1,31 @@
+# weaver live-check policy for the OBI semantic-convention registry.
+#
+# Auto-discovered by `weaver registry live-check` from the registry working
+# directory. Only the `live-check` section is used; `registry check` ignores it.
+#
+# This replaces two filters that previously lived in the Go harness
+# (internal/test/weavercheck): the advice-message ignore list and the
+# information-to-violation promotion. Weaver 0.25 can express both declaratively.
+
+# Promote advice weaver classifies as `information` to `violation` so live-check
+# fails on it. `extends_namespace` catches an attribute emitted under an existing
+# semconv namespace but declared in no registry; `undefined_enum_variant` catches
+# an enumerated attribute emitted with a value outside its declared members.
+[[live-check.finding_level_overrides]]
+ids = ["extends_namespace", "undefined_enum_variant"]
+level = "violation"
+
+# Accept the known namespace collisions OBI cannot avoid: the collector-contrib
+# servicegraph connector emits bare `server`/`client` labels, and netolly emits
+# `iface` alongside `iface.direction`, all colliding with upstream `*.address` /
+# `*.port` / `iface.direction` attributes. Scoped to those exact attribute
+# samples, so a collision on any other attribute still surfaces.
+[[live-check.finding_filters]]
+exclude = ["illegal_namespace"]
+sample_names = [
+  "server.address",
+  "server.port",
+  "client.address",
+  "client.port",
+  "iface.direction",
+]

--- a/scripts/lint-schema-filter.jq
+++ b/scripts/lint-schema-filter.jq
@@ -15,6 +15,12 @@
 #    id `x.obi.<ns>`) — either an enum extended with the values OBI
 #    intentionally emits, or an open-ended enum re-typed as string.
 #
+# 3. DeprecatedIncludeUnreferencedWarning: weaver 0.25 deprecated the
+#    `--include-unreferenced` flag, which OBI still needs — its override and
+#    marker groups are standalone (not referenced by a signal), so without it
+#    they drop out of resolution. `--future` promotes the deprecation to an
+#    error; accept it until OBI migrates to explicit `import:` statements.
+#
 # Any other diagnostic — including duplicates for other metrics/attributes,
 # or the expected ones with unexpected provenances/groups — is kept and fails
 # the lint. Covered by scripts/lint_schema_filter_test.go.
@@ -39,6 +45,10 @@ map(select(
              | ($groups | length) == 2
                and ($groups[0] | startswith("registry."))
                and $groups[1] == ("x.obi." + ($groups[0] | ltrimstr("registry."))))
+    )
+    or
+    (
+      (.error.DeprecatedIncludeUnreferencedWarning? // null) != null
     )
   ) | not
 ))

--- a/scripts/lint_schema_filter_test.go
+++ b/scripts/lint_schema_filter_test.go
@@ -108,6 +108,21 @@ func TestLintSchemaFilterAllowsExpectedEnumOverrideDuplicates(t *testing.T) {
 	}
 }
 
+// expectedDeprecatedIncludeUnreferenced mirrors the diagnostic weaver 0.25
+// emits (promoted to Error by --future) for OBI's use of the deprecated
+// --include-unreferenced flag, which OBI still needs.
+const expectedDeprecatedIncludeUnreferenced = `[{
+	"diagnostic": {"severity": "Error"},
+	"error": {"DeprecatedIncludeUnreferencedWarning": {}}
+}]`
+
+func TestLintSchemaFilterAllowsDeprecatedIncludeUnreferenced(t *testing.T) {
+	remaining := runLintSchemaFilter(t, expectedDeprecatedIncludeUnreferenced)
+	if len(remaining) != 0 {
+		t.Fatalf("expected the deprecated include-unreferenced warning to be filtered, got %d diagnostics", len(remaining))
+	}
+}
+
 func TestLintSchemaFilterKeepsUnrelatedDiagnostics(t *testing.T) {
 	cases := map[string]string{
 		"duplicate of another metric": `[{


### PR DESCRIPTION
## Summary

Bumps weaver to `v0.25.1` and modernizes how OBI runs its live-check semantic-convention validation.
Main goal is to minimize custom weaver handling and use its pre-built features, also reduces code on our side:

**Filtering moves into the registry (`.weaver.toml`).** Weaver 0.25 can declare finding filters and level overrides in the registry, so the hand-rolled advice classification in `weavercheck` is gone. `schemas/obi/.weaver.toml` promotes `extends_namespace` / `undefined_enum_variant` to `violation` and drops the known-safe `illegal_namespace` collisions (`server`/`client` address+port, `iface.direction`); a novel collision on any other sample still fails. `Validate` now just enforces "zero violations".

**The report is read over the admin `/stop` HTTP response, made safe by a `compact` format.** The harness POSTs `/stop` and reads the report from the response body (weaver runs with `--output http`) — no shared bind mount or `docker wait`. Weaver's builtin JSON report is ~135 MB for a real multi-language suite (every sample with its full body, each advisory repeated), big enough that weaver can close the connection before the client drains it — the truncation that made earlier HTTP attempts fail. A custom `compact` output template (`schemas/obi/.live_check_templates/compact/`) reduces the body to tens of KB via a jq filter: the statistics block plus a deduplicated findings list (message, level, advice type, count, and the distinct signals that triggered it) — bounded by distinct message/signal pairs, not sample count. That clears the socket buffer before weaver exits, so the body arrives intact. `weavercheck.Report` carries those `Findings` and `Validate` logs the same violation-first, level-grouped breakdown as before.

**Also:** re-enables OATS weaver validation (drops a stray `|| true`); adds a `lint-schema` allowlist clause for 0.25's `DeprecatedIncludeUnreferencedWarning` (OBI still needs `--include-unreferenced`); and groups all six `otel/weaver:` Renovate refs — including `service.yml`, previously tracked by no manager — so they bump together.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
