### PR TITLE
test: run an init in integration containers to stop the port-leak cascade

### DIFF
--- a/.github/actions/docker-init-default/action.yml
+++ b/.github/actions/docker-init-default/action.yml
@@ -1,0 +1,21 @@
+name: Enable docker init default
+description: >-
+  Run an init (tini) as PID 1 in every container so `docker compose down` reaps
+  zombie processes and never leaves a container holding a published host port,
+  which would fail the next suite's `compose up` with "port is already allocated".
+runs:
+  using: composite
+  steps:
+    - name: Enable docker daemon init default
+      shell: bash
+      run: |
+        sudo mkdir -p /etc/docker
+        if [ -f /etc/docker/daemon.json ]; then
+          merged=$(sudo jq '. + {init: true}' /etc/docker/daemon.json)
+        else
+          merged='{"init": true}'
+        fi
+        echo "$merged" | sudo tee /etc/docker/daemon.json >/dev/null
+        sudo systemctl restart docker
+        for _ in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
+        docker info --format 'docker init binary: {{.InitBinary}}'

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -167,6 +167,9 @@ jobs:
       - name: Build test tools
         run: make prereqs
 
+      - name: Enable docker init default
+        uses: ./.github/actions/docker-init-default
+
       - name: Restore base images
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] key derives from the digest-pinned base-image list; images are content-addressable
         with:

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -173,6 +173,9 @@ jobs:
       - name: Build test tools
         run: make prereqs
 
+      - name: Enable docker init default
+        uses: ./.github/actions/docker-init-default
+
       - name: Restore base images
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] key derives from the digest-pinned base-image list; images are content-addressable
         with:

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Build test tools
         run: make prereqs
 
+      - name: Enable docker init default
+        uses: ./.github/actions/docker-init-default
+
       - name: Verify OBI compiles
         run: docker build -f internal/test/integration/components/obi/Dockerfile .
 

--- a/internal/test/integration/components/docker/compose.go
+++ b/internal/test/integration/components/docker/compose.go
@@ -105,8 +105,17 @@ func (c *Compose) Stop() error {
 	return c.command("stop", "--timeout", stopTimeout)
 }
 
+// Remove tears the project down completely: containers, the default network,
+// anonymous volumes, and any orphaned containers left attached to the project
+// network by an earlier crashed step. `compose rm` would remove only the
+// declared, already-stopped containers and leave a leaked one holding its
+// published host port — which fails the next suite's `compose up` with
+// "port is already allocated".
 func (c *Compose) Remove() error {
-	cmdArgs := []string{"compose", "--ansi", "never", "-f", c.Path, "rm", "-f", "-v"}
+	cmdArgs := []string{
+		"compose", "--ansi", "never", "-f", c.Path,
+		"down", "--remove-orphans", "--volumes", "--timeout", stopTimeout,
+	}
 	cmd := exec.Command("docker", cmdArgs...)
 	cmd.Env = c.Env
 

--- a/internal/test/vm/Dockerfile
+++ b/internal/test/vm/Dockerfile
@@ -19,16 +19,7 @@ RUN apk update && apk add --no-cache \
     iptables \
     iptables-legacy \
     make \
-    openrc \
-    tini
-
-# Run an init (tini) as PID 1 in every container. Without it a container whose
-# main process leaves a zombie child can't be killed on `compose down`, survives
-# teardown holding its published host port, and fails the next suite's
-# `compose up` with "port is already allocated". Alpine's docker package has no
-# bundled docker-init, so point init-path at the tini binary explicitly.
-RUN mkdir -p /etc/docker && \
-    printf '{ "init": true, "init-path": "/sbin/tini" }\n' > /etc/docker/daemon.json
+    openrc
 
 # Default iptables symlink to legacy; modules-load may relink to nft on
 # RHEL kernels that lack CONFIG_IP_NF_NAT modules.

--- a/internal/test/vm/Dockerfile
+++ b/internal/test/vm/Dockerfile
@@ -19,7 +19,16 @@ RUN apk update && apk add --no-cache \
     iptables \
     iptables-legacy \
     make \
-    openrc
+    openrc \
+    tini
+
+# Run an init (tini) as PID 1 in every container. Without it a container whose
+# main process leaves a zombie child can't be killed on `compose down`, survives
+# teardown holding its published host port, and fails the next suite's
+# `compose up` with "port is already allocated". Alpine's docker package has no
+# bundled docker-init, so point init-path at the tini binary explicitly.
+RUN mkdir -p /etc/docker && \
+    printf '{ "init": true, "init-path": "/sbin/tini" }\n' > /etc/docker/daemon.json
 
 # Default iptables symlink to legacy; modules-load may relink to nft on
 # RHEL kernels that lack CONFIG_IP_NF_NAT modules.


### PR DESCRIPTION
## What

Integration-test shards intermittently fail with a cascade of

```
Bind for 0.0.0.0:8080 failed: port is already allocated
```

that no rerun can clear. This makes every container run under an init process so
teardown is clean and ports are freed.

## Why

When a container's PID 1 is the app itself (a bare `node`/`python`/`java`/`go`
process, or `obi`) and it leaves a zombie child or ignores SIGTERM,
`docker compose down` can't kill it and logs `is zombie and can not be killed.
Use the --init option`. The container survives teardown still holding its
published host port, so the next suite's `compose up` fails with "port is
already allocated" and every remaining suite on that shard cascades red.
`--rerun-fails` can't help — the port stays leaked for the rest of the
sequential run.

It reproduces on ~1 in 5 runs, concentrated on the `GRPCRelay` suite
(`testserver:8080`, `prometheus:9090`), and is independent of the code under
test.

## Change

Run an init (tini) as PID 1 in every container — exactly what the docker error
recommends — set as a daemon default so it applies everywhere without editing
~78 compose files:

- **CI runners**: a small composite action, `.github/actions/docker-init-default`,
  merges `{"init": true}` into `/etc/docker/daemon.json` and restarts docker.
  It's called before the base images load in the sharded, ARM, and OATS
  integration workflows.
- **Test VM** (`internal/test/vm/Dockerfile`): install `tini` and ship a
  `daemon.json` with `init: true` and an explicit `init-path` (the Alpine docker
  package has no bundled docker-init). This invalidates the `vm-rootfs` cache
  once.
- **Teardown** (`components/docker/compose.go`): `Remove()` now runs
  `compose down --remove-orphans --volumes` instead of `compose rm -f -v`, so
  the project network and any orphaned/leaked container are cleared too — a
  belt-and-suspenders guarantee of a clean slate between suites.

## Testing

- `go build` / `go vet` / `gofmt` clean; the composite action's script passes
  `shellcheck`; all workflow YAML validated.
- The daemon step logs a non-empty `InitBinary`, and the `GRPCRelay` shard
  should stop producing "port is already allocated" across repeated runs.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
