### PR TITLE
fix(discover): report failed uprobe attach instead of counting it as instrumented

### DIFF
--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -168,7 +168,6 @@ func (ta *traceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 
 		// allowing the tracer to forward traces from the new PID and its children processes
 		ta.monitorPIDs(tracer, ie)
-		ta.Metrics.InstrumentProcess(ie.FileInfo.ExecutableName())
 		if tracer.Type == ebpf.Generic {
 			// We need to do this because generic tracers have shared libraries. For example,
 			// a python executable can run an SSL and non-SSL application, so it's not enough
@@ -177,6 +176,10 @@ func (ta *traceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 			ok = ta.updateTracerProbes(tracer, ie)
 		} else {
 			ta.monitorPIDs(ta.reusableGoTracer, ie)
+		}
+		// only count the process once its probes are actually attached
+		if ok {
+			ta.Metrics.InstrumentProcess(ie.FileInfo.ExecutableName())
 		}
 		ta.log.Debug(".done", "success", ok)
 		return ok
@@ -365,6 +368,8 @@ func (ta *traceAttacher) reuseTracer(tracer *ebpf.ProcessTracer, ie *ebpf.Instru
 
 	if err := tracer.NewExecutable(exe, ie); err != nil {
 		ta.log.Debug("Failed to attach uprobes for new executable", "pid", ie.FileInfo.Pid(), "error", err)
+		ta.Metrics.InstrumentationError(ie.FileInfo.ExecutableName(), imetrics.InstrumentationErrorAttachingUprobe)
+		return false
 	}
 
 	ta.log.Debug("reusing Generic tracer for",
@@ -386,6 +391,8 @@ func (ta *traceAttacher) reuseTracer(tracer *ebpf.ProcessTracer, ie *ebpf.Instru
 func (ta *traceAttacher) updateTracerProbes(tracer *ebpf.ProcessTracer, ie *ebpf.Instrumentable) bool {
 	if err := tracer.NewExecutableInstance(ie); err != nil {
 		ta.log.Debug("Failed to attach uprobes", "pid", ie.FileInfo.Pid(), "error", err)
+		ta.Metrics.InstrumentationError(ie.FileInfo.ExecutableName(), imetrics.InstrumentationErrorAttachingUprobe)
+		return false
 	}
 
 	ta.log.Debug("reusing Generic tracer for",

--- a/pkg/appolly/discover/attacher_linux_test.go
+++ b/pkg/appolly/discover/attacher_linux_test.go
@@ -8,17 +8,23 @@ package discover
 import (
 	"errors"
 	"log/slog"
+	"os"
+	"syscall"
 	"testing"
+	"time"
 
+	"github.com/cilium/ebpf/link"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	execpkg "go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/ebpf"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/helpers/maps"
+	"go.opentelemetry.io/obi/pkg/internal/transform/route/harvest"
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
@@ -77,4 +83,101 @@ func TestCommonTracersPrunedAfterLoadFailure(t *testing.T) {
 	ta.notifyProcessDeletion(ie)
 	assert.NotEmpty(t, okTracer.blocked)
 	assert.Empty(t, failedTracer.blocked)
+}
+
+type recordingMetricsReporter struct {
+	imetrics.NoopReporter
+	instrumentedProcesses []string
+	instrumentationErrors []string
+}
+
+func (r *recordingMetricsReporter) InstrumentProcess(processName string) {
+	r.instrumentedProcesses = append(r.instrumentedProcesses, processName)
+}
+
+func (r *recordingMetricsReporter) InstrumentationError(_ string, errorType string) {
+	r.instrumentationErrors = append(r.instrumentationErrors, errorType)
+}
+
+// A failed uprobe attach on the reuse path must not be reported as an
+// instrumented process: that is how #2838-class breakage hides from operators.
+func TestReuseTracer_DoesNotReportFailedInstrumentation(t *testing.T) {
+	const missingPID app.PID = 999999999
+
+	metrics := &recordingMetricsReporter{}
+	cfg := &obi.Config{}
+	tracer := ebpf.NewProcessTracer(ebpf.Go, nil, cfg, metrics)
+	fileInfo := execpkg.New(execpkg.Init{
+		CmdExePath:     "/bin/test",
+		ProExeLinkPath: "/proc/self/exe",
+		Pid:            missingPID,
+		Dev:            100,
+		Ino:            1234,
+	})
+	ie := &ebpf.Instrumentable{FileInfo: fileInfo}
+	ta := &traceAttacher{
+		log:             slog.With("component", t.Name()),
+		Metrics:         metrics,
+		existingTracers: map[ebpf.ExecutableKey]executableTracer{},
+	}
+
+	ok := ta.reuseTracer(tracer, ie)
+
+	assert.False(t, ok)
+	assert.Empty(t, metrics.instrumentedProcesses)
+	assert.Equal(t, []string{imetrics.InstrumentationErrorAttachingUprobe}, metrics.instrumentationErrors)
+	assert.Empty(t, ta.existingTracers)
+}
+
+func TestGetTracer_DoesNotReportFailedExistingGenericInstrumentation(t *testing.T) {
+	const missingPID app.PID = 999999999
+
+	executablePath, err := os.Executable()
+	require.NoError(t, err)
+	statInfo, err := os.Stat(executablePath)
+	require.NoError(t, err)
+	stat, ok := statInfo.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+
+	metrics := &recordingMetricsReporter{}
+	cfg := &obi.Config{}
+	tracer := ebpf.NewProcessTracer(ebpf.Generic, nil, cfg, metrics)
+	currentFileInfo := execpkg.New(execpkg.Init{
+		CmdExePath:     executablePath,
+		ProExeLinkPath: "/proc/self/exe",
+		Pid:            app.PID(os.Getpid()),
+		Dev:            stat.Dev,
+		Ino:            stat.Ino,
+	})
+	exe, err := link.OpenExecutable(currentFileInfo.ProExeLinkPath())
+	require.NoError(t, err)
+	require.NoError(t, tracer.NewExecutable(exe, &ebpf.Instrumentable{FileInfo: currentFileInfo}))
+
+	failedFileInfo := execpkg.New(execpkg.Init{
+		CmdExePath:     executablePath,
+		ProExeLinkPath: "/proc/self/exe",
+		Pid:            missingPID,
+		Dev:            stat.Dev,
+		Ino:            stat.Ino,
+	})
+	ie := &ebpf.Instrumentable{
+		Type:     svc.InstrumentableGeneric,
+		FileInfo: failedFileInfo,
+	}
+	ta := &traceAttacher{
+		log:     slog.With("component", t.Name()),
+		Cfg:     cfg,
+		Metrics: metrics,
+		existingTracers: map[ebpf.ExecutableKey]executableTracer{
+			executableKey(failedFileInfo): {tracer: tracer, generation: 1},
+		},
+		routeHarvester: harvest.NewRouteHarvester(&cfg.Discovery.RouteHarvestConfig, nil, time.Second),
+	}
+
+	success := ta.getTracer(ie)
+
+	assert.False(t, success)
+	assert.Empty(t, metrics.instrumentedProcesses)
+	assert.Equal(t, []string{imetrics.InstrumentationErrorAttachingUprobe}, metrics.instrumentationErrors)
+	assert.Len(t, ta.existingTracers, 1)
 }

--- a/pkg/appolly/discover/attacher_test.go
+++ b/pkg/appolly/discover/attacher_test.go
@@ -6,6 +6,7 @@ package discover
 import (
 	"context"
 	"io"
+	"log/slog"
 	"testing"
 
 	cebpf "github.com/cilium/ebpf"
@@ -21,6 +22,7 @@ import (
 	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/goexec"
+	"go.opentelemetry.io/obi/pkg/internal/helpers/maps"
 	"go.opentelemetry.io/obi/pkg/internal/testutil"
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
@@ -225,4 +227,42 @@ func startDeletedTyperPipeline(
 			}
 		}
 	}()
+}
+
+// Deleting one executable must only tear down the tracer registered under its
+// own {device, inode} key, never a same-inode sibling from another filesystem.
+func TestNotifyProcessDeletion_DistinguishesDevicesForSameInode(t *testing.T) {
+	tracerEventsQu := msg.NewQueue[Event[*ebpf.Instrumentable]](msg.ChannelBufferLen(10))
+	tracerEvents := tracerEventsQu.Subscribe()
+
+	firstFile := execpkg.New(execpkg.Init{CmdExePath: "/bin/test", Pid: 41, Dev: 100, Ino: 1234, Ns: 17})
+	secondFile := execpkg.New(execpkg.Init{CmdExePath: "/bin/test", Pid: 42, Dev: 200, Ino: 1234, Ns: 17})
+
+	firstProgram := &recordingTracer{}
+	firstTracer := &ebpf.ProcessTracer{Type: ebpf.Go, Programs: []ebpf.Tracer{firstProgram}}
+	secondProgram := &recordingTracer{}
+	secondTracer := &ebpf.ProcessTracer{Type: ebpf.Go, Programs: []ebpf.Tracer{secondProgram}}
+
+	ta := &traceAttacher{
+		log:                slog.Default(),
+		Metrics:            imetrics.NoopReporter{},
+		existingTracers:    map[ebpf.ExecutableKey]executableTracer{},
+		processInstances:   maps.MultiCounter[ebpf.ExecutableKey]{},
+		OutputTracerEvents: tracerEventsQu,
+	}
+	ta.existingTracers[executableKey(firstFile)] = executableTracer{tracer: firstTracer, generation: 1}
+	ta.processInstances.Inc(executableKey(firstFile))
+	ta.existingTracers[executableKey(secondFile)] = executableTracer{tracer: secondTracer, generation: 2}
+	ta.processInstances.Inc(executableKey(secondFile))
+
+	ta.notifyProcessDeletion(&ebpf.Instrumentable{FileInfo: firstFile})
+
+	ev := testutil.ReadChannel(t, tracerEvents, testTimeout)
+	require.Equal(t, EventDeleted, ev.Type)
+	assert.Same(t, firstTracer, ev.Obj.Tracer)
+	assert.Equal(t, uint64(1), ev.Obj.ExecutableGeneration)
+	assert.Equal(t, []blockedPID{{pid: 41, ns: 17}}, firstProgram.blocked)
+	assert.Empty(t, secondProgram.blocked)
+	assert.Len(t, ta.existingTracers, 1)
+	assert.Contains(t, ta.existingTracers, executableKey(secondFile))
 }

--- a/pkg/ebpf/tracer_linux_test.go
+++ b/pkg/ebpf/tracer_linux_test.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	execpkg "go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+)
+
+type recordingCloser struct {
+	closed bool
+}
+
+func (r *recordingCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+// Containers sharing an image share one instrumenter: unlinking one executable
+// must not close the Go probe links the surviving siblings depend on.
+func TestUnlinkExecutable_SharedInstrumenterSurvivesSiblingUnlink(t *testing.T) {
+	firstKey := ExecutableKey{Dev: 100, Ino: 1234}
+	secondKey := ExecutableKey{Dev: 200, Ino: 1234}
+	closer := &recordingCloser{}
+
+	shared := &instrumenter{
+		key:        firstKey,
+		references: 2,
+		closables:  []io.Closer{closer},
+	}
+	tracer := &ProcessTracer{
+		log:  slog.Default(),
+		Type: Go,
+		Instrumentables: map[ExecutableKey]*instrumenter{
+			firstKey:  shared,
+			secondKey: shared,
+		},
+		instrumentableGenerations: map[ExecutableKey]uint64{
+			firstKey:  1,
+			secondKey: 2,
+		},
+		goInstrumentablesByInode: map[uint64]*instrumenter{1234: shared},
+	}
+	firstFile := execpkg.New(execpkg.Init{Dev: 100, Ino: 1234})
+	secondFile := execpkg.New(execpkg.Init{Dev: 200, Ino: 1234})
+
+	// a stale generation must not unlink anything
+	tracer.UnlinkExecutable(firstFile, 999)
+	assert.False(t, closer.closed)
+	assert.Len(t, tracer.Instrumentables, 2)
+
+	tracer.UnlinkExecutable(firstFile, 1)
+	assert.False(t, closer.closed)
+	assert.Contains(t, tracer.goInstrumentablesByInode, uint64(1234))
+	assert.Len(t, tracer.Instrumentables, 1)
+
+	tracer.UnlinkExecutable(secondFile, 2)
+	assert.True(t, closer.closed)
+	assert.Empty(t, tracer.goInstrumentablesByInode)
+	assert.Empty(t, tracer.Instrumentables)
+}


### PR DESCRIPTION
Upstream main now tracks executables per `{Dev, Ino}` with shared per-inode Go instrumenters, which supersedes the refcounting this branch originally carried. After rebasing, the branch narrows to the observability gap behind #2838: a failed uprobe attach on the tracer-reuse paths was logged at debug level and still counted in `instrumented_processes`, so pods without working probes looked healthy.

- `reuseTracer` / `updateTracerProbes` return failure and emit the attach-error metric instead of pretending success
- the tracer-reuse branch reports `InstrumentProcess` only after probes actually attached
- regression tests: shared-inode instrumenter survival across sibling unlinks, stale-generation unlink handling, per-device deletion isolation, and both failure-reporting paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)