### PR TITLE
test: deterministically cover obi.otel.metric.export.errors in weaver

### DIFF
--- a/internal/test/integration/configs/obi-config-internal-metrics-metric-errors.yml
+++ b/internal/test/integration/configs/obi-config-internal-metrics-metric-errors.yml
@@ -1,0 +1,14 @@
+# OBI config for the internal-metrics metric-export-error weaver suite. OBI's
+# metrics endpoint points at the collector, which is held down for the first
+# ~25s by a gate container while OBI (which does not wait for it) keeps trying
+# to export and fails, incrementing obi.otel.metric.export.errors. Once the
+# collector comes up, the now-non-zero counter is exported over the same otel
+# internal-metrics path to weaver for semantic-convention live-check.
+otel_metrics_export:
+  endpoint: http://otelcol:4318
+internal_metrics:
+  exporter: otel
+attributes:
+  select:
+    "*":
+      include: ["*"]

--- a/internal/test/integration/docker-compose-internal-metrics-metric-errors.yml
+++ b/internal/test/integration/docker-compose-internal-metrics-metric-errors.yml
@@ -1,0 +1,94 @@
+services:
+  # Holds the collector down for a fixed window so OBI's early metric exports
+  # fail deterministically (rather than relying on an incidental startup race).
+  gate:
+    image: busybox:1.37.0
+    command: ["sh", "-c", "sleep 25"]
+
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/testserver/Dockerfile
+    image: hatest-testserver
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    environment:
+      - LOG_LEVEL=DEBUG
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-internal-metrics-metric-errors:/var/run/obi
+      - /sys/kernel/tracing:/sys/kernel/tracing:rw
+    image: hatest-obi
+    privileged: true
+    pid: "host"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: /configs/obi-config-internal-metrics-metric-errors.yml
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_METRIC_SCRAPE_INTERVAL: "1s"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_OPEN_PORT: "8080"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+    # Intentionally does NOT depend on otelcol, so OBI starts exporting while the
+    # collector is still gated down and its exports fail.
+    depends_on:
+      testserver:
+        condition: service_started
+
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config-internal-metrics.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  # Comes up only after the gate's window elapses (and weaver is healthy). Until
+  # then OBI's metric exports to :4318 are refused, incrementing the error
+  # counter; afterwards metrics fan out to prometheus (scraped) and to weaver.
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.158.0@sha256:c5918f78992ee73b0d6f0e599423ac5ec52dd5d9726733114d6eca53d5a32ed5
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver-no-jaeger.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317"
+      - "4318:4318"
+      - "9464"
+      - "8888"
+    depends_on:
+      gate:
+        condition: service_completed_successfully
+      prometheus:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro

--- a/internal/test/integration/internal_metrics_metric_errors_otel_test.go
+++ b/internal/test/integration/internal_metrics_metric_errors_otel_test.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration // import "go.opentelemetry.io/obi/internal/test/integration"
+
+import (
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
+	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
+)
+
+const internalMetricsMetricErrorsHostPort = "8399"
+
+// TestInternalOTelMetricsMetricErrors holds the collector down for a fixed
+// window (a gate container) while OBI, which does not wait for it, keeps trying
+// to export metrics and fails. instrumentedMetricsExporter.Export observes each
+// failure and records obi.otel.metric.export.errors. Once the collector comes
+// up, the now-non-zero counter is exported over the same otel internal-metrics
+// path to Prometheus (asserted present here) and to weaver for
+// semantic-convention live-check. This makes the metric-export-error metric
+// deterministically covered rather than relying on an incidental startup race.
+func TestInternalOTelMetricsMetricErrors(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-internal-metrics-metric-errors.yml", path.Join(pathOutput, "test-suite-internal-metrics-metric-errors.log"))
+	require.NoError(t, err)
+	compose.Env = append(compose.Env, `TEST_SERVICE_PORTS=`+internalMetricsMetricErrorsHostPort+`:8080`)
+	require.NoError(t, compose.Up())
+
+	// Cleanups run LIFO: register compose.Close() first so it runs LAST, after
+	// runWeaverValidation has /stopped the still-running weaver container.
+	t.Cleanup(func() { require.NoError(t, compose.Close()) })
+	t.Cleanup(func() { runWeaverValidation(t) })
+
+	t.Run("obi.otel.metric.export.errors exported over OTLP and weaver-validated", func(t *testing.T) {
+		pq := promtest.Client{HostPort: prometheusHostPort}
+
+		require.Eventually(t, func() bool {
+			return pokeInternalMetricsMetricErrorsServer() == nil
+		}, testTimeout, 500*time.Millisecond, "testserver never became reachable")
+
+		// Drive continuous HTTP traffic so OBI keeps producing application
+		// metrics it then tries (and, while the collector is gated down, fails)
+		// to export, incrementing obi.otel.metric.export.errors.
+		stop := make(chan struct{})
+		go func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = pokeInternalMetricsMetricErrorsServer()
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
+		}()
+		defer close(stop)
+
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			results, err := pq.Query("obi_otel_metric_export_errors_total")
+			if !assert.NoError(ct, err, "querying obi_otel_metric_export_errors_total") {
+				return
+			}
+			assert.NotEmpty(ct, results, "obi_otel_metric_export_errors_total should be present")
+		}, testTimeout, 500*time.Millisecond)
+	})
+}
+
+func pokeInternalMetricsMetricErrorsServer() error {
+	client := http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://localhost:" + internalMetricsMetricErrorsHostPort + "/ping")
+	if err != nil {
+		return err
+	}
+	return resp.Body.Close()
+}


### PR DESCRIPTION
## Summary

Internal metrics share the app-metrics OTLP exporter, so failing the metrics endpoint also breaks the path that would report the error counter. Instead a gate container holds the collector down for a fixed window while OBI (which does not wait for it) keeps trying to export and fails, incrementing obi.otel.metric.export.errors; once the collector comes up the non-zero counter is exported to weaver.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
