### PR TITLE
Conform to OTEL messaging semantic conventions

### DIFF
--- a/internal/test/integration/red_test_kafka.go
+++ b/internal/test/integration/red_test_kafka.go
@@ -87,10 +87,10 @@ func testREDMetricsPythonKafkaOnly(t *testing.T) {
 			Comm:    "python3.14",
 			Spans: []TestCaseSpan{
 				{
-					Name: "publish my-topic",
+					Name: "send my-topic",
 					Attributes: []attribute.KeyValue{
 						attribute.String("span.kind", "producer"),
-						attribute.String("messaging.operation.type", "publish"),
+						attribute.String("messaging.operation.type", "send"),
 						attribute.String("messaging.destination.name", "my-topic"),
 						attribute.String("messaging.client.id", "kafka-python-producer-1"),
 						attribute.String("messaging.destination.partition.id", "0"),
@@ -134,10 +134,10 @@ func testJavaKafka(t *testing.T, port int, comm string) {
 			Comm:    comm,
 			Spans: []TestCaseSpan{
 				{
-					Name: "publish my-topic",
+					Name: "send my-topic",
 					Attributes: []attribute.KeyValue{
 						attribute.String("span.kind", "producer"),
-						attribute.String("messaging.operation.type", "publish"),
+						attribute.String("messaging.operation.type", "send"),
 						attribute.String("messaging.destination.name", "my-topic"),
 						attribute.String("messaging.client.id", "producer-1"),
 						attribute.String("messaging.destination.partition.id", "0"),
@@ -186,10 +186,10 @@ func testJavaKafkaLargeBuffer(t *testing.T) {
 			Comm:    "javakafka-lb",
 			Spans: []TestCaseSpan{
 				{
-					Name: "publish theotelebpfagentisperfectlyimpatientitskipsthecodethesdkandfindsthekernelssecretkeyitwatcheshttpandgrpctogiveyoumetricsforfreeapowerfulkernellevelspree",
+					Name: "send theotelebpfagentisperfectlyimpatientitskipsthecodethesdkandfindsthekernelssecretkeyitwatcheshttpandgrpctogiveyoumetricsforfreeapowerfulkernellevelspree",
 					Attributes: []attribute.KeyValue{
 						attribute.String("span.kind", "producer"),
-						attribute.String("messaging.operation.type", "publish"),
+						attribute.String("messaging.operation.type", "send"),
 						attribute.String("messaging.destination.name", "theotelebpfagentisperfectlyimpatientitskipsthecodethesdkandfindsthekernelssecretkeyitwatcheshttpandgrpctogiveyoumetricsforfreeapowerfulkernellevelspree"),
 						attribute.String("messaging.client.id", "producer-1"),
 						attribute.String("messaging.destination.partition.id", "0"),
@@ -240,10 +240,10 @@ func testNodeRdkafka(t *testing.T) {
 			Comm:    "node",
 			Spans: []TestCaseSpan{
 				{
-					Name: "publish obi-node-rdkafka-topic",
+					Name: "send obi-node-rdkafka-topic",
 					Attributes: []attribute.KeyValue{
 						attribute.String("span.kind", "producer"),
-						attribute.String("messaging.operation.type", "publish"),
+						attribute.String("messaging.operation.type", "send"),
 						attribute.String("messaging.destination.name", "obi-node-rdkafka-topic"),
 					},
 				},
@@ -279,7 +279,7 @@ func testNodeRdkafka(t *testing.T) {
 // regardless of the broker's topic ordering.
 //
 // Note the asymmetry: the Apache Java producer sends a separate single-topic
-// Produce per topic, so the `publish <topic>` assertions pass even without the
+// Produce per topic, so the `send <topic>` assertions pass even without the
 // multi-topic changes. The real coverage is the `process <topic>` assertions:
 // the Java consumer issues one multi-topic Fetch (all subscribed topics by UUID),
 // so all three `process` spans appearing is what proves the metadata
@@ -300,10 +300,10 @@ func testJavaKafkaMultiTopic(t *testing.T) {
 	for _, topic := range topics {
 		spans = append(spans,
 			TestCaseSpan{
-				Name: "publish " + topic,
+				Name: "send " + topic,
 				Attributes: []attribute.KeyValue{
 					attribute.String("span.kind", "producer"),
-					attribute.String("messaging.operation.type", "publish"),
+					attribute.String("messaging.operation.type", "send"),
 					attribute.String("messaging.destination.name", topic),
 				},
 			},

--- a/internal/test/integration/red_test_mqtt.go
+++ b/internal/test/integration/red_test_mqtt.go
@@ -79,7 +79,7 @@ func testREDMetricsMQTTPublish(t *testing.T, comm string, warmupConnect bool) {
 					Name: "publish test/topic",
 					Attributes: []attribute.KeyValue{
 						attribute.String("span.kind", "producer"),
-						attribute.String("messaging.operation.type", "publish"),
+						attribute.String("messaging.operation.type", "send"),
 						attribute.String("messaging.destination.name", "test/topic"),
 					},
 				},

--- a/internal/test/integration/traces_test.go
+++ b/internal/test/integration/traces_test.go
@@ -1715,13 +1715,13 @@ func testGoGenericHTTPTraces(t *testing.T) {
 			server := res[0]
 			require.NotEmpty(ct, server.TraceID)
 
-			res = trace.FindByOperationName("publish my-topic", "producer")
+			res = trace.FindByOperationName("send my-topic", "producer")
 			require.Len(ct, res, 1)
 			client := res[0]
 			// Check parenthood
 			assert.Equal(ct, server.TraceID, client.TraceID)
 			sd := client.Diff(
-				jaeger.Tag{Key: "messaging.operation.type", Type: "string", Value: "publish"},
+				jaeger.Tag{Key: "messaging.operation.type", Type: "string", Value: "send"},
 				jaeger.Tag{Key: "messaging.system", Type: "string", Value: "kafka"},
 				jaeger.Tag{Key: "span.kind", Type: "string", Value: "producer"},
 			)
@@ -1833,13 +1833,13 @@ func testGoGenericHTTPSTraces(t *testing.T) {
 			server := res[0]
 			require.NotEmpty(ct, server.TraceID)
 
-			res = trace.FindByOperationName("publish my-topic", "producer")
+			res = trace.FindByOperationName("send my-topic", "producer")
 			require.Len(ct, res, 1)
 			client := res[0]
 			// Check parenthood
 			assert.Equal(ct, server.TraceID, client.TraceID)
 			sd := client.Diff(
-				jaeger.Tag{Key: "messaging.operation.type", Type: "string", Value: "publish"},
+				jaeger.Tag{Key: "messaging.operation.type", Type: "string", Value: "send"},
 				jaeger.Tag{Key: "messaging.system", Type: "string", Value: "kafka"},
 				jaeger.Tag{Key: "span.kind", Type: "string", Value: "producer"},
 			)

--- a/internal/test/oats/amqp/yaml/oats_java_amqp.yaml
+++ b/internal/test/oats/amqp/yaml/oats_java_amqp.yaml
@@ -7,17 +7,19 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ kind=producer && .messaging.system = "amqp" && .messaging.operation.type = "publish" }'
+  - traceql: '{ kind=producer && .messaging.system = "amqp" && .messaging.operation.type = "send" }'
     equals: publish
     attributes:
       messaging.system: amqp
-      messaging.operation.type: publish
+      messaging.operation.type: send
+      messaging.operation.name: publish
       server.port: '5672'
   - traceql: '{ kind=consumer && .messaging.system = "amqp" && .messaging.operation.type = "process" }'
     equals: process
     attributes:
       messaging.system: amqp
       messaging.operation.type: process
+      messaging.operation.name: process
       server.port: '5672'
   metrics:
   - promql: messaging_client_operation_duration_seconds_count{messaging_system="amqp"}

--- a/internal/test/oats/amqp/yaml/oats_python_amqp.yaml
+++ b/internal/test/oats/amqp/yaml/oats_python_amqp.yaml
@@ -7,17 +7,19 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ kind=producer && .messaging.system = "amqp" && .messaging.operation.type = "publish" }'
+  - traceql: '{ kind=producer && .messaging.system = "amqp" && .messaging.operation.type = "send" }'
     equals: publish
     attributes:
       messaging.system: amqp
-      messaging.operation.type: publish
+      messaging.operation.type: send
+      messaging.operation.name: publish
       server.port: '5672'
   - traceql: '{ kind=consumer && .messaging.system = "amqp" && .messaging.operation.type = "process" }'
     equals: process
     attributes:
       messaging.system: amqp
       messaging.operation.type: process
+      messaging.operation.name: process
       server.port: '5672'
   metrics:
   - promql: messaging_client_operation_duration_seconds_count{messaging_system="amqp"}

--- a/internal/test/oats/kafka/yaml/oats_go_kafka-generic.yaml
+++ b/internal/test/oats/kafka/yaml/oats_go_kafka-generic.yaml
@@ -8,11 +8,12 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="my-topic"}'
-    equals: publish my-topic
+  - traceql: '{ .messaging.operation.type = "send" && .messaging.destination.name="my-topic"}'
+    equals: send my-topic
     attributes:
       messaging.destination.name: my-topic
-      messaging.operation.type: publish
+      messaging.operation.type: send
+      messaging.operation.name: send
       messaging.system: kafka
       server.port: '9093'
   - traceql: '{ .http.route = "/produce" }'

--- a/internal/test/oats/kafka/yaml/oats_go_kafka-go-topic.yaml
+++ b/internal/test/oats/kafka/yaml/oats_go_kafka-go-topic.yaml
@@ -8,11 +8,12 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="logging" && kind = producer }'
-    equals: publish logging
+  - traceql: '{ .messaging.operation.type = "send" && .messaging.destination.name="logging" && kind = producer }'
+    equals: send logging
     attributes:
       messaging.destination.name: logging
-      messaging.operation.type: publish
+      messaging.operation.type: send
+      messaging.operation.name: send
       messaging.system: kafka
       server.port: '9092'
   - traceql: '{ .messaging.operation.type = "process" && .messaging.destination.name="logging" && kind = consumer }'
@@ -20,6 +21,7 @@ expected:
     attributes:
       messaging.destination.name: logging
       messaging.operation.type: process
+      messaging.operation.name: process
       messaging.system: kafka
       server.port: '9092'
   metrics:

--- a/internal/test/oats/kafka/yaml/oats_go_kafka-go.yaml
+++ b/internal/test/oats/kafka/yaml/oats_go_kafka-go.yaml
@@ -8,11 +8,12 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="logging" && kind = producer }'
-    equals: publish logging
+  - traceql: '{ .messaging.operation.type = "send" && .messaging.destination.name="logging" && kind = producer }'
+    equals: send logging
     attributes:
       messaging.destination.name: logging
-      messaging.operation.type: publish
+      messaging.operation.type: send
+      messaging.operation.name: send
       messaging.system: kafka
       server.port: '9092'
   - traceql: '{ .messaging.operation.type = "process" && .messaging.destination.name="logging" && kind = consumer }'
@@ -20,6 +21,7 @@ expected:
     attributes:
       messaging.destination.name: logging
       messaging.operation.type: process
+      messaging.operation.name: process
       messaging.system: kafka
       server.port: '9092'
   metrics:

--- a/internal/test/oats/kafka/yaml/oats_go_kafka-sarama-no-promise.yaml
+++ b/internal/test/oats/kafka/yaml/oats_go_kafka-sarama-no-promise.yaml
@@ -8,10 +8,11 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="orders"}'
-    equals: publish orders
+  - traceql: '{ .messaging.operation.type = "send" && .messaging.destination.name="orders"}'
+    equals: send orders
     attributes:
       messaging.destination.name: orders
-      messaging.operation.type: publish
+      messaging.operation.type: send
+      messaging.operation.name: send
       messaging.system: kafka
       server.port: '9092'

--- a/internal/test/oats/kafka/yaml/oats_go_kafka-sarama.yaml
+++ b/internal/test/oats/kafka/yaml/oats_go_kafka-sarama.yaml
@@ -13,20 +13,23 @@ expected:
     attributes:
       messaging.destination.name: important
       messaging.operation.type: process
+      messaging.operation.name: process
       messaging.system: kafka
       server.port: '9092'
-  - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="important"}'
-    equals: publish important
+  - traceql: '{ .messaging.operation.type = "send" && .messaging.destination.name="important"}'
+    equals: send important
     attributes:
       messaging.destination.name: important
-      messaging.operation.type: publish
+      messaging.operation.type: send
+      messaging.operation.name: send
       messaging.system: kafka
       server.port: '9092'
-  - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="access_log"}'
-    equals: publish access_log
+  - traceql: '{ .messaging.operation.type = "send" && .messaging.destination.name="access_log"}'
+    equals: send access_log
     attributes:
       messaging.destination.name: access_log
-      messaging.operation.type: publish
+      messaging.operation.type: send
+      messaging.operation.name: send
       messaging.system: kafka
       server.port: '9092'
   metrics:

--- a/internal/test/oats/kafka/yaml/oats_java_kafka.yaml
+++ b/internal/test/oats/kafka/yaml/oats_java_kafka.yaml
@@ -12,12 +12,14 @@ expected:
     regexp: ^process
     attributes:
       messaging.operation.type: process
+      messaging.operation.name: process
       messaging.system: kafka
       server.port: '9092'
-  - traceql: '{ .messaging.operation.type = "publish" }'
-    regexp: ^publish
+  - traceql: '{ .messaging.operation.type = "send" }'
+    regexp: ^send
     attributes:
-      messaging.operation.type: publish
+      messaging.operation.type: send
+      messaging.operation.name: send
       messaging.system: kafka
       server.port: '9092'
   metrics:

--- a/internal/test/oats/kafka/yaml/oats_python_kafka.yaml
+++ b/internal/test/oats/kafka/yaml/oats_python_kafka.yaml
@@ -13,13 +13,15 @@ expected:
     attributes:
       messaging.destination.name: my-topic
       messaging.operation.type: process
+      messaging.operation.name: process
       messaging.system: kafka
       server.port: '9092'
-  - traceql: '{ .messaging.operation.type = "publish" }'
-    equals: publish my-topic
+  - traceql: '{ .messaging.operation.type = "send" }'
+    equals: send my-topic
     attributes:
       messaging.destination.name: my-topic
-      messaging.operation.type: publish
+      messaging.operation.type: send
+      messaging.operation.name: send
       messaging.system: kafka
       server.port: '9092'
   metrics:

--- a/internal/test/oats/nats/yaml/oats_python_nats.yaml
+++ b/internal/test/oats/nats/yaml/oats_python_nats.yaml
@@ -8,11 +8,12 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .messaging.system = "nats" && .messaging.operation.type = "publish" && .messaging.destination.name = "updates.orders" }'
+  - traceql: '{ .messaging.system = "nats" && .messaging.operation.type = "send" && .messaging.destination.name = "updates.orders" }'
     equals: publish updates.orders
     attributes:
       messaging.destination.name: updates.orders
-      messaging.operation.type: publish
+      messaging.operation.type: send
+      messaging.operation.name: publish
       messaging.system: nats
       server.port: '4222'
   - traceql: '{ .messaging.system = "nats" && .messaging.operation.type = "process" && .messaging.destination.name = "updates.orders" }'
@@ -20,6 +21,7 @@ expected:
     attributes:
       messaging.destination.name: updates.orders
       messaging.operation.type: process
+      messaging.operation.name: process
       messaging.system: nats
       server.port: '4222'
   metrics:

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -203,9 +203,18 @@ func (t EventType) MarshalText() ([]byte, error) {
 }
 
 const (
+	MessagingSend    = "send"
+	MessagingReceive = "receive"
 	MessagingPublish = "publish"
 	MessagingProcess = "process"
 )
+
+func MessagingOperationTypeOf(operationName string) string {
+	if operationName == MessagingPublish {
+		return MessagingSend
+	}
+	return operationName
+}
 
 type converter struct {
 	clock     func() time.Time
@@ -1895,8 +1904,8 @@ func (s *Span) ServiceGraphKind() string {
 	case EventTypeHTTPClient, EventTypeGRPCClient, EventTypeSQLClient, EventTypeRedisClient, EventTypeMongoClient, EventTypeFailedConnect, EventTypeCouchbaseClient, EventTypeMemcachedClient, EventTypeSunRPCClient:
 		return "SPAN_KIND_CLIENT"
 	case EventTypeKafkaClient, EventTypeMQTTClient, EventTypeNATSClient, EventTypeAMQPClient:
-		switch s.Method {
-		case MessagingPublish:
+		switch MessagingOperationTypeOf(s.Method) {
+		case MessagingSend:
 			return "SPAN_KIND_PRODUCER"
 		case MessagingProcess:
 			return "SPAN_KIND_CONSUMER"

--- a/pkg/appolly/app/request/span_getters.go
+++ b/pkg/appolly/app/request/span_getters.go
@@ -285,7 +285,7 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 				EventTypeMQTTClient, EventTypeMQTTServer,
 				EventTypeNATSClient, EventTypeNATSServer,
 				EventTypeAMQPClient:
-				opType = span.Method
+				opType = MessagingOperationTypeOf(span.Method)
 			}
 			if span.Type == EventTypeHTTPClient && span.SubType == HTTPSubtypeAWSSQS && span.AWS != nil {
 				opType = span.AWS.SQS.OperationType

--- a/pkg/appolly/app/request/span_getters_test.go
+++ b/pkg/appolly/app/request/span_getters_test.go
@@ -401,9 +401,9 @@ func TestSpanOTELGetters_MessagingOpName(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "kafka client publish",
-			span:     &Span{Type: EventTypeKafkaClient, Method: MessagingPublish},
-			expected: "publish",
+			name:     "kafka client send",
+			span:     &Span{Type: EventTypeKafkaClient, Method: MessagingSend},
+			expected: "send",
 		},
 		{
 			name:     "kafka server process",
@@ -434,6 +434,16 @@ func TestSpanOTELGetters_MessagingOpName(t *testing.T) {
 			name:     "amqp client publish",
 			span:     &Span{Type: EventTypeAMQPClient, Method: MessagingPublish},
 			expected: "publish",
+		},
+		{
+			name: "aws sqs client uses the sqs operation name",
+			span: &Span{
+				Type:    EventTypeHTTPClient,
+				SubType: HTTPSubtypeAWSSQS,
+				Method:  "POST",
+				AWS:     &AWS{SQS: AWSSQS{OperationName: "SendMessage"}},
+			},
+			expected: "SendMessage",
 		},
 		{
 			name:     "http span returns empty",
@@ -783,7 +793,7 @@ func TestSpanOTELGetters_MessagingAttributes_NATS(t *testing.T) {
 
 	opTypeGetter, ok := spanOTELGetters(attr.MessagingOpType)
 	require.True(t, ok, "getter should be found for MessagingOpType")
-	assert.Equal(t, MessagingPublish, opTypeGetter(span).Value.AsString())
+	assert.Equal(t, MessagingSend, opTypeGetter(span).Value.AsString())
 
 	span.Method = MessagingProcess
 	assert.Equal(t, MessagingProcess, opTypeGetter(span).Value.AsString())

--- a/pkg/appolly/app/request/span_test.go
+++ b/pkg/appolly/app/request/span_test.go
@@ -86,7 +86,7 @@ func TestKindString(t *testing.T) {
 		{Type: EventTypeRedisClient}:                           "SPAN_KIND_CLIENT",
 		{Type: EventTypeMemcachedClient}:                       "SPAN_KIND_CLIENT",
 		{Type: EventTypeMongoClient}:                           "SPAN_KIND_CLIENT",
-		{Type: EventTypeKafkaClient, Method: MessagingPublish}: "SPAN_KIND_PRODUCER",
+		{Type: EventTypeKafkaClient, Method: MessagingSend}:    "SPAN_KIND_PRODUCER",
 		{Type: EventTypeKafkaClient, Method: MessagingProcess}: "SPAN_KIND_CONSUMER",
 		{Type: EventTypeMQTTClient, Method: MessagingPublish}:  "SPAN_KIND_PRODUCER",
 		{Type: EventTypeMQTTClient, Method: MessagingProcess}:  "SPAN_KIND_CONSUMER",
@@ -116,7 +116,7 @@ func TestServiceGraphConnectionType(t *testing.T) {
 		{name: "Elasticsearch client", span: &Span{Type: EventTypeHTTPClient, SubType: HTTPSubtypeElasticsearch}, expected: "database"},
 
 		// Messaging client spans should return "messaging_system"
-		{name: "Kafka client producer", span: &Span{Type: EventTypeKafkaClient, Method: MessagingPublish}, expected: "messaging_system"},
+		{name: "Kafka client producer", span: &Span{Type: EventTypeKafkaClient, Method: MessagingSend}, expected: "messaging_system"},
 		{name: "Kafka client consumer", span: &Span{Type: EventTypeKafkaClient, Method: MessagingProcess}, expected: "messaging_system"},
 		{name: "MQTT client publisher", span: &Span{Type: EventTypeMQTTClient, Method: MessagingPublish}, expected: "messaging_system"},
 		{name: "MQTT client subscriber", span: &Span{Type: EventTypeMQTTClient, Method: MessagingProcess}, expected: "messaging_system"},
@@ -179,10 +179,10 @@ func TestTraceName(t *testing.T) {
 		{name: "Memcached empty", span: &Span{Type: EventTypeMemcachedClient}, expected: "MEMCACHED"},
 
 		// Kafka spans
-		{name: "Kafka client publish", span: &Span{Type: EventTypeKafkaClient, Method: MessagingPublish, Path: "orders"}, expected: "publish orders"},
+		{name: "Kafka client send", span: &Span{Type: EventTypeKafkaClient, Method: MessagingSend, Path: "orders"}, expected: "send orders"},
 		{name: "Kafka client process", span: &Span{Type: EventTypeKafkaClient, Method: MessagingProcess, Path: "events"}, expected: "process events"},
 		{name: "Kafka server", span: &Span{Type: EventTypeKafkaServer, Method: MessagingProcess, Path: "topic"}, expected: "process topic"},
-		{name: "Kafka no topic", span: &Span{Type: EventTypeKafkaClient, Method: MessagingPublish}, expected: "publish"},
+		{name: "Kafka no topic", span: &Span{Type: EventTypeKafkaClient, Method: MessagingSend}, expected: "send"},
 
 		// MQTT spans
 		{name: "MQTT client publish", span: &Span{Type: EventTypeMQTTClient, Method: MessagingPublish, Path: "sensors/temperature"}, expected: "publish sensors/temperature"},
@@ -2118,6 +2118,23 @@ func TestSpan_GenAIResponseModel_OpenAICompatible(t *testing.T) {
 				},
 			}
 			assert.Equal(t, tt.want, span.GenAIResponseModel())
+		})
+	}
+}
+
+func TestMessagingOperationTypeOf(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		operationName string
+		expected      string
+	}{
+		{name: "publish maps to send", operationName: MessagingPublish, expected: MessagingSend},
+		{name: "send is unchanged", operationName: MessagingSend, expected: MessagingSend},
+		{name: "process is unchanged", operationName: MessagingProcess, expected: MessagingProcess},
+		{name: "unknown stays empty", operationName: "", expected: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, MessagingOperationTypeOf(tc.operationName))
 		})
 	}
 }

--- a/pkg/ebpf/common/go_kafka_transform_test.go
+++ b/pkg/ebpf/common/go_kafka_transform_test.go
@@ -31,7 +31,7 @@ func TestReadGoKafkaGoRequestIntoSpanOperation(t *testing.T) {
 		{
 			name:     "produce",
 			apiKey:   kafkaGoAPIProduce,
-			method:   request.MessagingPublish,
+			method:   request.MessagingSend,
 			spanKind: "SPAN_KIND_PRODUCER",
 		},
 	}

--- a/pkg/ebpf/common/http/aws_sqs.go
+++ b/pkg/ebpf/common/http/aws_sqs.go
@@ -118,9 +118,9 @@ func parseSQSDestination(queueURL string) string {
 func inferSQSOperationType(opName string) string {
 	switch opName {
 	case "SendMessage", "SendMessageBatch":
-		return "send"
+		return request.MessagingSend
 	case "ReceiveMessage":
-		return "receive"
+		return request.MessagingReceive
 	default:
 		return ""
 	}

--- a/pkg/ebpf/common/kafka_detect_transform.go
+++ b/pkg/ebpf/common/kafka_detect_transform.go
@@ -42,7 +42,7 @@ type KafkaInfo struct {
 func (k Operation) String() string {
 	switch k {
 	case Produce:
-		return request.MessagingPublish
+		return request.MessagingSend
 	case Fetch:
 		return request.MessagingProcess
 	default:

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -1037,8 +1037,8 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 			}
 		case request.EventTypeKafkaClient, request.EventTypeKafkaServer:
 			if mr.is.KafkaEnabled() {
-				switch span.Method {
-				case request.MessagingPublish:
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
 					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
 					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 				case request.MessagingProcess:
@@ -1048,8 +1048,8 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 			}
 		case request.EventTypeMQTTClient, request.EventTypeMQTTServer:
 			if mr.is.MQTTEnabled() {
-				switch span.Method {
-				case request.MessagingPublish:
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
 					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
 					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 				case request.MessagingProcess:
@@ -1059,8 +1059,8 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 			}
 		case request.EventTypeNATSClient, request.EventTypeNATSServer:
 			if mr.is.NATSEnabled() {
-				switch span.Method {
-				case request.MessagingPublish:
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
 					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
 					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 				case request.MessagingProcess:
@@ -1070,8 +1070,8 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 			}
 		case request.EventTypeAMQPClient:
 			if mr.is.AMQPEnabled() {
-				switch span.Method {
-				case request.MessagingPublish:
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
 					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
 					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 				case request.MessagingProcess:

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -423,7 +423,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMemcachedServer, Method: "GET", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMongoClient, Method: "find", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeAerospikeClient, Method: "aerospike_get", RequestStart: 150, End: 175},
-				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeKafkaClient, Method: "publish", RequestStart: 150, End: 175},
+				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeKafkaClient, Method: request.MessagingSend, RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeKafkaServer, Method: "process", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMQTTClient, Method: "publish", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMQTTServer, Method: "process", RequestStart: 150, End: 175},
@@ -1395,7 +1395,7 @@ func TestConnectionTypeForSpan(t *testing.T) {
 		},
 		{
 			name:     "Kafka producer",
-			span:     &request.Span{Type: request.EventTypeKafkaClient, Method: request.MessagingPublish, HostName: "kafka-broker"},
+			span:     &request.Span{Type: request.EventTypeKafkaClient, Method: request.MessagingSend, HostName: "kafka-broker"},
 			expected: "messaging_system",
 		},
 		{

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -540,6 +540,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 		attrs := spans.At(0).Attributes()
 		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpType), "process")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpName), "process")
 		ensureTraceStrAttr(t, attrs, semconv.MessagingDestinationNameKey, "important-topic")
 		ensureTraceStrAttr(t, attrs, semconv.MessagingClientIDKey, "test")
 	})
@@ -558,7 +559,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		assert.NotEmpty(t, spans.At(0).TraceID().String())
 
 		attrs := spans.At(0).Attributes()
-		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpType), "publish")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpType), "send")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpName), "publish")
 		ensureTraceStrAttr(t, attrs, semconv.MessagingDestinationNameKey, "sensors/temperature")
 		ensureTraceStrAttr(t, attrs, semconv.MessagingClientIDKey, "mqtt-client-1")
 	})
@@ -583,11 +585,47 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		assert.NotEmpty(t, spans.At(0).TraceID().String())
 
 		attrs := spans.At(0).Attributes()
-		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpType), "publish")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpType), "send")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpName), "publish")
 		ensureTraceStrAttr(t, attrs, semconv.MessagingDestinationNameKey, "updates.orders")
 		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingSystem), "nats")
 		ensureTraceStrAttr(t, attrs, semconv.MessagingClientIDKey, "nats-client-1")
 		ensureTraceIntAttr(t, attrs, semconv.MessagingMessageEnvelopeSizeKey, 42)
+	})
+
+	t.Run("test Kafka producer trace generation", func(t *testing.T) {
+		span := request.Span{
+			Type:      request.EventTypeKafkaClient,
+			Method:    request.MessagingSend,
+			Path:      "important-topic",
+			Statement: "test",
+		}
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
+
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+		assert.Equal(t, "send important-topic", spans.At(0).Name())
+		assert.Equal(t, ptrace.SpanKindProducer, spans.At(0).Kind())
+
+		attrs := spans.At(0).Attributes()
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpName), "send")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpType), "send")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingSystem), "kafka")
+	})
+
+	t.Run("test AMQP trace generation", func(t *testing.T) {
+		span := request.Span{
+			Type:   request.EventTypeAMQPClient,
+			Method: "publish",
+		}
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
+
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+		attrs := spans.At(0).Attributes()
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpType), "send")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingOpName), "publish")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.MessagingSystem), "amqp")
 	})
 
 	t.Run("test Kafka trace generation omits unknown operation type", func(t *testing.T) {
@@ -600,6 +638,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
 		attrs := spans.At(0).Attributes()
 		ensureTraceAttrNotExists(t, attrs, attribute.Key(attr.MessagingOpType))
+		ensureTraceAttrNotExists(t, attrs, attribute.Key(attr.MessagingOpName))
 		ensureTraceStrAttr(t, attrs, semconv.MessagingDestinationNameKey, "important-topic")
 	})
 
@@ -2564,7 +2603,7 @@ func TestTracesInstrumentations(t *testing.T) {
 		{
 			name:     "all instrumentations",
 			instr:    []instrumentations.Instrumentation{instrumentations.InstrumentationALL},
-			expected: []string{"GET /foo", "PUT /bar", "/grpcFoo", "/grpcGoo", "SELECT credentials", "SET", "GET", "publish important-topic", "process important-topic", "publish sensors/temperature", "process sensors/#", "publish updates.orders", "process updates.orders", "portmapper/0", "insert mycollection", "GET couchbase-collection", "GET", "DELETE"},
+			expected: []string{"GET /foo", "PUT /bar", "/grpcFoo", "/grpcGoo", "SELECT credentials", "SET", "GET", "send important-topic", "process important-topic", "publish sensors/temperature", "process sensors/#", "publish updates.orders", "process updates.orders", "portmapper/0", "insert mycollection", "GET couchbase-collection", "GET", "DELETE"},
 		},
 		{
 			name:     "http only",
@@ -2589,7 +2628,7 @@ func TestTracesInstrumentations(t *testing.T) {
 		{
 			name:     "kafka only",
 			instr:    []instrumentations.Instrumentation{instrumentations.InstrumentationKafka},
-			expected: []string{"publish important-topic", "process important-topic"},
+			expected: []string{"send important-topic", "process important-topic"},
 		},
 		{
 			name:     "mqtt only",
@@ -2619,7 +2658,7 @@ func TestTracesInstrumentations(t *testing.T) {
 		{
 			name:     "kafka and grpc",
 			instr:    []instrumentations.Instrumentation{instrumentations.InstrumentationGRPC, instrumentations.InstrumentationKafka},
-			expected: []string{"/grpcFoo", "/grpcGoo", "publish important-topic", "process important-topic"},
+			expected: []string{"/grpcFoo", "/grpcGoo", "send important-topic", "process important-topic"},
 		},
 		{
 			name:     "mongo",
@@ -2646,8 +2685,8 @@ func TestTracesInstrumentations(t *testing.T) {
 		makeSQLRequestSpan("SELECT password FROM credentials WHERE username=\"bill\""),
 		{Service: svc.Attrs{UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeRedisClient, Method: "SET", Path: "redis_db", RequestStart: 150, End: 175},
 		{Service: svc.Attrs{UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeRedisServer, Method: "GET", Path: "redis_db", RequestStart: 150, End: 175},
-		{Type: request.EventTypeKafkaClient, Method: "process", Path: "important-topic", Statement: "test"},
-		{Type: request.EventTypeKafkaServer, Method: "publish", Path: "important-topic", Statement: "test"},
+		{Type: request.EventTypeKafkaClient, Method: request.MessagingSend, Path: "important-topic", Statement: "test"},
+		{Type: request.EventTypeKafkaServer, Method: "process", Path: "important-topic", Statement: "test"},
 		{Type: request.EventTypeMQTTClient, Method: "publish", Path: "sensors/temperature", Statement: "mqtt-client"},
 		{Type: request.EventTypeMQTTServer, Method: "process", Path: "sensors/#", Statement: "mqtt-server"},
 		{Type: request.EventTypeNATSClient, Method: "publish", Path: "updates.orders"},

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -534,6 +534,16 @@ func appendGenAITokenCount(attrs []attribute.KeyValue, key attribute.Key, count 
 	return attrs
 }
 
+func messagingOperationAttrs(method string) []attribute.KeyValue {
+	if method == "" {
+		return nil
+	}
+	return []attribute.KeyValue{
+		request.MessagingOperationName(method),
+		request.MessagingOperationType(request.MessagingOperationTypeOf(method)),
+	}
+}
+
 //nolint:cyclop
 func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.Name]struct{}, redactSet map[string]struct{}) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
@@ -1398,11 +1408,7 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			semconv.MessagingDestinationName(span.Path),
 			semconv.MessagingClientID(span.Statement),
 		}
-		// messaging.operation.type is a semconv enum: omit it instead of
-		// emitting an empty (invalid) variant when the operation is unknown.
-		if span.Method != "" {
-			attrs = append(attrs, request.MessagingOperationType(span.Method))
-		}
+		attrs = append(attrs, messagingOperationAttrs(span.Method)...)
 
 		if span.Type == request.EventTypeKafkaClient {
 			attrs = append(attrs, request.PeerService(request.PeerServiceFromSpan(span)))
@@ -1422,9 +1428,7 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			semconv.MessagingDestinationName(span.Path),
 			semconv.MessagingClientID(span.Statement),
 		}
-		if span.Method != "" {
-			attrs = append(attrs, request.MessagingOperationType(span.Method))
-		}
+		attrs = append(attrs, messagingOperationAttrs(span.Method)...)
 
 		if span.Type == request.EventTypeMQTTClient {
 			attrs = append(attrs, request.PeerService(request.PeerServiceFromSpan(span)))
@@ -1438,9 +1442,7 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			semconv.MessagingClientID(span.Statement),
 			semconv.MessagingMessageEnvelopeSize(int(span.ContentLength)),
 		}
-		if span.Method != "" {
-			attrs = append(attrs, request.MessagingOperationType(span.Method))
-		}
+		attrs = append(attrs, messagingOperationAttrs(span.Method)...)
 
 		if span.Type == request.EventTypeNATSClient {
 			attrs = append(attrs, request.PeerService(request.PeerServiceFromSpan(span)))
@@ -1451,9 +1453,7 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			request.ServerPort(span.HostPort),
 			messagingSystemAMQP,
 		}
-		if span.Method != "" {
-			attrs = append(attrs, request.MessagingOperationType(span.Method))
-		}
+		attrs = append(attrs, messagingOperationAttrs(span.Method)...)
 
 		attrs = append(attrs, request.PeerService(request.PeerServiceFromSpan(span)))
 	case request.EventTypeSunRPCServer, request.EventTypeSunRPCClient:
@@ -1680,8 +1680,8 @@ func spanKind(span *request.Span) trace2.SpanKind {
 	case request.EventTypeHTTPClient, request.EventTypeGRPCClient, request.EventTypeSQLClient, request.EventTypeRedisClient, request.EventTypeMongoClient, request.EventTypeCouchbaseClient, request.EventTypeMemcachedClient, request.EventTypeSunRPCClient, request.EventTypeAerospikeClient, request.EventTypeFailedConnect:
 		return trace2.SpanKindClient
 	case request.EventTypeKafkaClient, request.EventTypeMQTTClient, request.EventTypeNATSClient, request.EventTypeAMQPClient:
-		switch span.Method {
-		case request.MessagingPublish:
+		switch request.MessagingOperationTypeOf(span.Method) {
+		case request.MessagingSend:
 			return trace2.SpanKindProducer
 		case request.MessagingProcess:
 			return trace2.SpanKindConsumer

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -1132,8 +1132,8 @@ func (r *metricsReporter) observe(span *request.Span) {
 			}
 		case request.EventTypeKafkaClient, request.EventTypeKafkaServer:
 			if r.is.KafkaEnabled() {
-				switch span.Method {
-				case request.MessagingPublish:
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
 					r.observeHistogram(r.msgPublishDuration.WithLabelValues(labelValues(span, r.attrMsgPublishDuration)...).Metric, duration, span)
 				case request.MessagingProcess:
 					r.observeHistogram(r.msgProcessDuration.WithLabelValues(labelValues(span, r.attrMsgProcessDuration)...).Metric, duration, span)
@@ -1141,8 +1141,8 @@ func (r *metricsReporter) observe(span *request.Span) {
 			}
 		case request.EventTypeMQTTClient, request.EventTypeMQTTServer:
 			if r.is.MQTTEnabled() {
-				switch span.Method {
-				case request.MessagingPublish:
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
 					r.observeHistogram(r.msgPublishDuration.WithLabelValues(labelValues(span, r.attrMsgPublishDuration)...).Metric, duration, span)
 				case request.MessagingProcess:
 					r.observeHistogram(r.msgProcessDuration.WithLabelValues(labelValues(span, r.attrMsgProcessDuration)...).Metric, duration, span)
@@ -1150,8 +1150,8 @@ func (r *metricsReporter) observe(span *request.Span) {
 			}
 		case request.EventTypeNATSClient, request.EventTypeNATSServer:
 			if r.is.NATSEnabled() {
-				switch span.Method {
-				case request.MessagingPublish:
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
 					r.msgPublishDuration.WithLabelValues(
 						labelValues(span, r.attrMsgPublishDuration)...,
 					).Metric.Observe(duration)
@@ -1163,8 +1163,8 @@ func (r *metricsReporter) observe(span *request.Span) {
 			}
 		case request.EventTypeAMQPClient:
 			if r.is.AMQPEnabled() {
-				switch span.Method {
-				case request.MessagingPublish:
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
 					r.observeHistogram(r.msgPublishDuration.WithLabelValues(labelValues(span, r.attrMsgPublishDuration)...).Metric, duration, span)
 				case request.MessagingProcess:
 					r.observeHistogram(r.msgProcessDuration.WithLabelValues(labelValues(span, r.attrMsgProcessDuration)...).Metric, duration, span)

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -513,7 +513,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeRedisServer, Method: "GET", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMemcachedClient, Method: "SET", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMemcachedServer, Method: "GET", RequestStart: 150, End: 175},
-				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeKafkaClient, Method: "publish", RequestStart: 150, End: 175},
+				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeKafkaClient, Method: request.MessagingSend, RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeKafkaServer, Method: "process", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMQTTClient, Method: "publish", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMQTTServer, Method: "process", RequestStart: 150, End: 175},


### PR DESCRIPTION
## Summary

Brings OBI's messaging spans in line with the messaging semantic conventions:

- **Emits `messaging.operation.name` on the Kafka / MQTT / NATS / AMQP trace path**, which the conventions mark `Required` on every messaging span. It was already a default-on attribute and already emitted on AWS SQS spans; the four broker protocols were the gap.
- **Stops emitting the deprecated `publish` operation type.** Semconv v1.41 deprecates `publish` in favour of `send`, so `messaging.operation.type` now reports `send` where it previously reported `publish`.

The two attributes carry different information, so they are now derived separately: `operation.name` is the system's own name for the call, while `operation.type` is the five-member semconv enum used to aggregate across brokers. They coincide for Kafka and for the consume side, and differ for MQTT / NATS / AMQP, which name the call `publish` but whose type is `send`. This mirrors how the Java and JS instrumentations derive the pair.

| System | `operation.name` | `operation.type` |
| --- | --- | --- |
| Kafka producer | `send` | `send` |
| MQTT / NATS / AMQP producer | `publish` | `send` |
| consumers | `process` | `process` |

`publish` is still a *declared* member of `messaging.operation.type` in v1.41, marked `deprecated: {renamed_to: send}`, so emitting it was never a live-check violation and nothing was failing. This is spec hygiene ahead of the deprecated member eventually being removed, not a fix for a broken build.

## Breaking changes

Five surfaces are visible to anything consuming OBI's messaging telemetry:

- `messaging.operation.type` reports `send` instead of `publish` on producer spans.
- Kafka producer span names change from `publish {topic}` to `send {topic}`, following the operation name. MQTT, NATS and AMQP span names are unchanged.
- The `messaging.operation.name` label on `messaging.client.operation.duration` changes from `publish` to `send` for Kafka producers, re-keying those series. MQTT, NATS and AMQP keep `publish`.
- The debug / JSON exporter prints `operation: send` for Kafka spans where it printed `operation: publish` (`spanAttributes()` surfaces `s.Method` directly).
- Span metrics re-key: `traces.span.metrics.calls` / `.duration` are grouped by `span.name`, which `spanMetricAttributes()` emits unconditionally (span metrics have no attribute selection). Every Kafka producer series moves from `span_name="publish {topic}"` to `span_name="send {topic}"`.

Dashboards, alerts or saved queries that match the old values need updating.

## Notes for reviewers

- Producer-side dispatch goes through `request.MessagingOperationTypeOf(span.Method)` rather than matching `send` and `publish` side by side. The normalisation lives in one function, so each call site matches the single canonical `send`, and adding a protocol that names the call something else does not mean touching every switch.
- `pkg/ebpf/common/http/aws_sqs.go` swaps its bare `"send"` / `"receive"` literals for the `request.MessagingSend` / `request.MessagingReceive` constants (the latter added for it). Behaviour-neutral, and included so the SQS path names these values the same way the code this PR touches does.
- Kafka consumer spans keep `operation.type: process`. The conventions model a broker fetch as a Receive span (`type: receive`, name `poll`), which is what the Java instrumentation emits; changing that also changes span kind mapping, so it is left for a separate change.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

