### PR TITLE
bpf: classify TCP client/server by the local port, not the sorted d_port

### DIFF
--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -265,9 +265,13 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
         }
     }
     if (!existing) {
+        // must check the local port: the peer port may also have a local
+        // listener (docker-proxy), which would misclassify a client as a server
+        const u16 local_port =
+            pid_conn->conn.d_port == orig_dport ? pid_conn->conn.s_port : pid_conn->conn.d_port;
         // Determining the server information for unix sockets is only valid on request creation
-        const bool is_server = is_listening(pid_conn->conn.d_port, netns) ||
-                               is_unix_sock_server(direction, orig_dport);
+        const bool is_server =
+            is_listening(local_port, netns) || is_unix_sock_server(direction, orig_dport);
         if (direction == TCP_RECV) {
             cp_support_data_t *tk = bpf_map_lookup_elem(&cp_support_connect_info, pid_conn);
             if (tk && tk->real_client) {

--- a/internal/test/integration/components/pythonmongo/main.py
+++ b/internal/test/integration/components/pythonmongo/main.py
@@ -11,14 +11,19 @@ client = None
 async def query():
     global client
     if client is None:
-        client = MongoClient("mongodb://mongo:27017/")  # or your MongoDB URI
+        client = MongoClient(os.environ.get("MONGO_URI", "mongodb://mongo:27017/"))
 
     # Select database and collection
     db = client["mydatabase"]
     collection = db["mycollection"]
 
-    # Insert a document
-    collection.insert_one({"name": "Alice", "age": 30})
+    # Insert a document. An optional payload makes the request and the find
+    # response exceed the small capture buffers, exercising the large-buffer path
+    doc = {"name": "Alice", "age": 30}
+    blob_bytes = int(os.environ.get("MONGO_BLOB_BYTES", "0"))
+    if blob_bytes > 0:
+        doc["blob"] = "x" * blob_bytes
+    collection.insert_one(doc)
 
     # # Find one document
     doc = collection.find_one({"name": "Alice"})

--- a/internal/test/integration/docker-compose-python-mongo-samenet.yml
+++ b/internal/test/integration/docker-compose-python-mongo-samenet.yml
@@ -1,0 +1,122 @@
+version: "3.8"
+
+# Same as docker-compose-python-mongo.yml, but mongo shares the client's
+# network namespace: the client then sees a local listener on the server port,
+# which used to misclassify it as a server and swap the large-buffer
+# request/response orientation.
+services:
+  mongo:
+    build:
+      context: ../../../internal/test/integration/components/mongo/
+      dockerfile: Dockerfile
+    image: mongo
+    network_mode: "service:testserver"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  testserver:
+    build:
+      context: ../../../internal/test/integration/components/pythonmongo/
+      dockerfile: Dockerfile
+    image: hatest-testserver-python-mongo
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    environment:
+      MONGO_URI: "mongodb://127.0.0.1:27017/"
+      MONGO_BLOB_BYTES: "1500"
+    depends_on:
+      otelcol:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-python:/var/run/obi
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_BPF_BUFFER_SIZE_TCP: "4096"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_TRACES_INSTRUMENTATIONS: "mongo"
+      OTEL_EBPF_METRICS_INSTRUMENTATIONS: "mongo"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+      OTEL_EBPF_PROTOCOL_DEBUG_PRINT: "true"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.159.0@sha256:1f2c54a30e713fac6b3ae77a1ec84010c2007e29ced8ec666214fc2f6739c1cc
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318:4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+      jaeger:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.14.0@sha256:5ce7540c3c00ef4ab0c9d2c995c6a5b9c421f44b4a115d97a2c7af3b1c21cbb0
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    command:
+      - "--set=service.telemetry.logs.level=debug"

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -821,6 +821,19 @@ func TestSuite_PythonMongo(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+// mongo shares the client's network namespace, so the client sees a local
+// listener on the server port
+func TestSuite_PythonMongoSameNetNS(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-python-mongo-samenet.yml", path.Join(pathOutput, "test-suite-python-mongo-samenet.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
+	require.NoError(t, compose.Up())
+	t.Run("Python Mongo same-netns metrics", testREDMetricsPythonMongoOnly)
+	runWeaverValidation(t)
+	require.NoError(t, compose.Close())
+}
+
 func TestSuite_PythonCouchbase(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-couchbase.yml", path.Join(pathOutput, "test-suite-python-couchbase.log"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Describe the change briefly.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
